### PR TITLE
HOTFIX - Corrige fetch da ultima OS capturada no flow de captura do GTFS

### DIFF
--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Changelog - gtfs
 
+## [1.0.1] - 2024-06-20
+
+### Corrigido
+
+- Corrige task `get_last_capture_os` para selecionar a key salva no dicionário do Redis (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/72)
+
 ## [1.0.0] - 2024-06-19
 
 ### Adicionado
 
 - Adicionada automação da captura do gtfs atravez da planilha Controle OS (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/62)
+
+

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/tasks.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/tasks.py
@@ -41,6 +41,8 @@ def get_last_capture_os(dataset_id: str, mode: str = "prod") -> dict:
         fetch_key = f"{mode}.{fetch_key}"
 
     last_captured_os = redis_client.get(fetch_key)
+    if last_captured_os is not None:
+        last_captured_os = last_captured_os["last_captured_os"]
 
     log(f"Last captured os: {last_captured_os}")
 


### PR DESCRIPTION
# Changelog - gtfs

## [1.0.1] - 2024-06-20

### Corrigido

- Corrige task `get_last_capture_os` para selecionar a key salva no dicionário do Redis