### PR TITLE
Cria flow de materialização de viagens da Zirix

### DIFF
--- a/pipelines/migration/br_rj_riodejaneiro_viagem_zirix/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_viagem_zirix/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog - viagem_zirix
+
+## [1.1.0] - 2024-06-26
+
+### Adicionado
+- Cria flow `viagem_zirix_materializacao` para materialização dos dados de viagens de ônibus enviados pela API da Zirix (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/81)

--- a/pipelines/migration/br_rj_riodejaneiro_viagem_zirix/constants.py
+++ b/pipelines/migration/br_rj_riodejaneiro_viagem_zirix/constants.py
@@ -22,3 +22,19 @@ class constants(Enum):  # pylint: disable=c0103
         "interval_minutes": 10,
         "source_type": "api-json",
     }
+
+    VIAGEM_MATERIALIZACAO_PARAMS = {
+        "dataset_id": smtr_constants.VIAGEM_ZIRIX_RAW_DATASET_ID.value,
+        "table_id": "viagem_informada",
+        "upstream": True,
+        "dbt_vars": {
+            "date_range": {
+                "table_run_datetime_column_name": "data",
+                "delay_hours": 1,
+            },
+            "version": {},
+        },
+        "source_dataset_ids": [smtr_constants.VIAGEM_ZIRIX_RAW_DATASET_ID.value],
+        "source_table_ids": [VIAGEM_CAPTURE_PARAMETERS["table_id"]],
+        "capture_intervals_minutes": [VIAGEM_CAPTURE_PARAMETERS["interval_minutes"]],
+    }

--- a/pipelines/migration/br_rj_riodejaneiro_viagem_zirix/flows.py
+++ b/pipelines/migration/br_rj_riodejaneiro_viagem_zirix/flows.py
@@ -13,9 +13,9 @@ from prefeitura_rio.pipelines_utils.state_handlers import (
 
 from pipelines.constants import constants as smtr_constants
 from pipelines.migration.br_rj_riodejaneiro_viagem_zirix.constants import constants
-from pipelines.migration.flows import default_capture_flow
+from pipelines.migration.flows import default_capture_flow, default_materialization_flow
 from pipelines.migration.utils import set_default_parameters
-from pipelines.schedules import every_10_minutes, every_hour
+from pipelines.schedules import every_10_minutes, every_hour, every_hour_minute_thirty
 
 # Flows #
 
@@ -51,3 +51,24 @@ viagens_recaptura = set_default_parameters(
 )
 
 viagens_recaptura.schedule = every_hour
+
+
+viagem_zirix_materializacao = deepcopy(default_materialization_flow)
+viagem_zirix_materializacao.name = "Viagem Zirix - Materialização"
+viagem_zirix_materializacao.storage = GCS(smtr_constants.GCS_FLOWS_BUCKET.value)
+viagem_zirix_materializacao.run_config = KubernetesRun(
+    image=smtr_constants.DOCKER_IMAGE.value,
+    labels=[smtr_constants.RJ_SMTR_AGENT_LABEL.value],
+)
+
+viagem_zirix_materializacao.state_handlers = [
+    handler_inject_bd_credentials,
+    handler_initialize_sentry,
+]
+
+viagem_zirix_materializacao = set_default_parameters(
+    flow=viagem_zirix_materializacao,
+    default_parameters=constants.VIAGEM_MATERIALIZACAO_PARAMS.value,
+)
+
+viagem_zirix_materializacao.schedule = every_hour_minute_thirty

--- a/pipelines/schedules.py
+++ b/pipelines/schedules.py
@@ -101,6 +101,18 @@ every_hour_minute_six = Schedule(
     ]
 )
 
+every_hour_minute_thirty = Schedule(
+    clocks=[
+        IntervalClock(
+            interval=timedelta(hours=1),
+            start_date=datetime(2021, 1, 1, 0, 30, 0, tzinfo=timezone(constants.TIMEZONE.value)),
+            labels=[
+                emd_constants.RJ_SMTR_AGENT_LABEL.value,
+            ],
+        ),
+    ]
+)
+
 every_day = Schedule(
     clocks=[
         IntervalClock(

--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -274,3 +274,9 @@ models:
       staging:
         +materialized: view
         +schema: controle_financeiro_staging
+    br_rj_riodejaneiro_viagem_zirix:
+      +materialized: table
+      +schema: br_rj_riodejaneiro_viagem_zirix
+      staging:
+        +materialized: view
+        +schema: br_rj_riodejaneiro_viagem_zirix_staging_dbt

--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -279,4 +279,4 @@ models:
       +schema: br_rj_riodejaneiro_viagem_zirix
       staging:
         +materialized: view
-        +schema: br_rj_riodejaneiro_viagem_zirix_staging_dbt
+        +schema: br_rj_riodejaneiro_viagem_zirix_staging

--- a/queries/models/br_rj_riodejaneiro_viagem_zirix/CHANGELOG.md
+++ b/queries/models/br_rj_riodejaneiro_viagem_zirix/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog - viagem_zirix
+
+## [1.0.0] - 2024-06-26
+
+### Adicionado
+- Cria modelos `staging_viagem_informada.sql` e `viagem_informada.sql` para tratamento dos dados de viagens de ônibus enviados pela API da Zirix (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/81)

--- a/queries/models/br_rj_riodejaneiro_viagem_zirix/schema.yml
+++ b/queries/models/br_rj_riodejaneiro_viagem_zirix/schema.yml
@@ -24,3 +24,5 @@ models:
         description: "Nome curto da linha operada pelo veículo com variação de serviço (ex: 010, 011SN, ...)"
       - name: sentido
         description: "Ida ou Volta"
+      - name: versao
+        description: "Código de controle de versão do dado (SHA Github)"

--- a/queries/models/br_rj_riodejaneiro_viagem_zirix/schema.yml
+++ b/queries/models/br_rj_riodejaneiro_viagem_zirix/schema.yml
@@ -12,6 +12,8 @@ models:
         description: "Data e hora da chegada da viagem em GMT-3"
       - name: datetime_processamento
         description: "Data e hora do processamento da viagem em GMT-3"
+      - name: datetime_captura
+        description: "Data e hora da captura da integração em GMT-3"
       - name: id_veiculo
         description: "Código identificador do veículo (número de ordem)"
       - name: trip_id
@@ -24,5 +26,9 @@ models:
         description: "Nome curto da linha operada pelo veículo com variação de serviço (ex: 010, 011SN, ...)"
       - name: sentido
         description: "Ida ou Volta"
+      - name: id_viagem
+        description: "Identificador de um shape da tabela shapes do GTFS"
       - name: versao
         description: "Código de controle de versão do dado (SHA Github)"
+      - name: datetime_ultima_atualizacao
+        description: "Última atualização (GMT-3)."

--- a/queries/models/br_rj_riodejaneiro_viagem_zirix/schema.yml
+++ b/queries/models/br_rj_riodejaneiro_viagem_zirix/schema.yml
@@ -1,0 +1,26 @@
+version: 2
+
+models:
+  - name: viagem_informada
+    description: "Detalhes das viagens informadas pelas operadoras de ônibus"
+    columns:
+      - name: data
+        description: "Data da viagem (partição)"
+      - name: datetime_partida
+        description: "Data e hora da partida da viagem em GMT-3"
+      - name: datetime_chegada
+        description: "Data e hora da chegada da viagem em GMT-3"
+      - name: datetime_processamento
+        description: "Data e hora do processamento da viagem em GMT-3"
+      - name: id_veiculo
+        description: "Código identificador do veículo (número de ordem)"
+      - name: trip_id
+        description: "Identificador de uma viagem da tabela trips do GTFS"
+      - name: route_id
+        description: "Identificador de uma rota da tabela routes do GTFS"
+      - name: shape_id
+        description: "Identificador de um shape da tabela shapes do GTFS"
+      - name: servico
+        description: "Nome curto da linha operada pelo veículo com variação de serviço (ex: 010, 011SN, ...)"
+      - name: sentido
+        description: "Ida ou Volta"

--- a/queries/models/br_rj_riodejaneiro_viagem_zirix/staging/staging_viagem_informada.sql
+++ b/queries/models/br_rj_riodejaneiro_viagem_zirix/staging/staging_viagem_informada.sql
@@ -1,0 +1,59 @@
+{{
+  config(
+    alias="viagem_informada"
+  )
+}}
+
+SELECT
+  id_viagem,
+  data,
+  hora,
+  DATETIME(PARSE_TIMESTAMP('%Y-%m-%d %H:%M:%S%Ez', timestamp_captura), "America/Sao_Paulo") AS timestamp_captura,
+  DATE(
+    PARSE_DATETIME(
+      '%Y-%m-%d',
+      SUBSTRING(
+        SAFE_CAST(JSON_VALUE(content, '$.data_viagem') AS STRING),
+        0,
+        10
+      )
+    )
+  ) AS data_viagem,
+  DATETIME(
+    PARSE_TIMESTAMP(
+      '%Y-%m-%dT%H:%M:%S',
+      REPLACE(
+        SAFE_CAST(JSON_VALUE(content, '$.datetime_chegada') AS STRING),
+        "Z",
+        ""
+      )
+    )
+  ) AS datetime_chegada,
+  DATETIME(
+    PARSE_TIMESTAMP(
+      '%Y-%m-%dT%H:%M:%S',
+      REPLACE(
+        SAFE_CAST(JSON_VALUE(content, '$.datetime_partida') AS STRING),
+        "Z",
+        ""
+      )
+    )
+  ) AS datetime_partida,
+  DATETIME(
+    PARSE_TIMESTAMP(
+      '%Y-%m-%dT%H:%M:%E*S',
+      REPLACE(
+        SAFE_CAST(JSON_VALUE(content, '$.datetime_processamento') AS STRING),
+        "Z",
+        ""
+      )
+    )
+  ) AS datetime_processamento,
+  SAFE_CAST(JSON_VALUE(content, '$.id_veiculo') AS STRING) AS id_veiculo,
+  SAFE_CAST(JSON_VALUE(content, '$.route_id') AS STRING) AS route_id,
+  SAFE_CAST(JSON_VALUE(content, '$.sentido') AS STRING) AS sentido,
+  SAFE_CAST(JSON_VALUE(content, '$.servico') AS STRING) AS servico,
+  SAFE_CAST(JSON_VALUE(content, '$.shape_id') AS STRING) AS shape_id,
+  SAFE_CAST(JSON_VALUE(content, '$.trip_id') AS STRING) AS trip_id
+FROM
+  {{ source("br_rj_riodejaneiro_viagem_zirix_staging", "viagem_informada") }}

--- a/queries/models/br_rj_riodejaneiro_viagem_zirix/viagem_informada.sql
+++ b/queries/models/br_rj_riodejaneiro_viagem_zirix/viagem_informada.sql
@@ -10,25 +10,91 @@
   )
 }}
 
+{% set incremental_filter %}
+  DATE(data) BETWEEN DATE("{{var('date_range_start')}}") AND DATE("{{var('date_range_end')}}")
+{% endset %}
+
+{% set staging_viagem_informada = ref('staging_viagem_informada') %}
+{% if execute %}
+  {% if is_incremental() %}
+    {% set partitions_query %}
+      SELECT DISTINCT
+        CONCAT("'", DATE(data_viagem), "'") AS data_viagem
+      FROM
+        {{ staging_viagem_informada }}
+      WHERE
+        {{ incremental_filter }}
+    {% endset %}
+
+    {% set partitions = run_query(partitions_query)[0].values() %}
+  {% endif %}
+{% endif %}
+
+WITH staging_data AS (
+  SELECT
+    data_viagem AS data,
+    datetime_partida,
+    datetime_chegada,
+    datetime_processamento,
+    timestamp_captura AS datetime_captura,
+    id_veiculo,
+    trip_id,
+    route_id,
+    shape_id,
+    servico,
+    CASE
+      WHEN sentido = 'I' THEN 'Ida'
+      WHEN sentido = 'V' THEN 'Volta'
+      ELSE sentido
+    END AS sentido,
+    id_viagem
+  FROM
+    {{ staging_viagem_informada }}
+  {% if is_incremental() %}
+    WHERE
+      {{ incremental_filter }}
+  {% endif %}
+),
+complete_partitions AS (
+  SELECT
+    *,
+    0 AS priority
+  FROM
+    staging_data
+
+  {% if is_incremental() and partitions|length > 0 %}
+    UNION ALL
+
+    SELECT
+      * EXCEPT(versao, datetime_ultima_atualizacao),
+      1 AS priority
+    FROM
+      {{ this }}
+    WHERE
+      data IN ({{ partitions|join(', ') }})
+  {% endif %}
+),
+deduplicado AS (
+  SELECT
+    * EXCEPT(rn, priority)
+  FROM
+    (
+      SELECT
+        *,
+        ROW_NUMBER() OVER(PARTITION BY id_viagem ORDER BY datetime_captura DESC, priority) AS rn
+      FROM
+        complete_partitions
+    )
+  WHERE
+    rn = 1
+)
 SELECT
-  data_viagem AS data,
-  datetime_partida,
-  datetime_chegada,
-  datetime_processamento,
-  id_veiculo,
-  trip_id,
-  route_id,
-  shape_id,
-  servico,
-  CASE
-    WHEN sentido = 'I' THEN 'Ida'
-    WHEN sentido = 'V' THEN 'Volta'
-    ELSE sentido
-  END AS sentido,
-  '{{ var("version") }}' AS versao
+  *,
+  '{{ var("version") }}' AS versao,
+  CURRENT_DATETIME("America/Sao_Paulo") as datetime_ultima_atualizacao
 FROM
-  {{ ref("staging_viagem_informada") }}
+  {{ staging_viagem_informada }}
 {% if is_incremental() %}
   WHERE
-    data BETWEEN DATE("{{var('date_range_start')}}") AND DATE("{{var('date_range_end')}}")
+    {{ incremental_filter }}
 {% endif %}

--- a/queries/models/br_rj_riodejaneiro_viagem_zirix/viagem_informada.sql
+++ b/queries/models/br_rj_riodejaneiro_viagem_zirix/viagem_informada.sql
@@ -25,6 +25,7 @@ SELECT
     WHEN sentido = 'V' THEN 'Volta'
     ELSE sentido
   END AS sentido,
+  '{{ var("version") }}' AS versao
 FROM
   {{ ref("staging_viagem_informada") }}
 {% if is_incremental() %}

--- a/queries/models/br_rj_riodejaneiro_viagem_zirix/viagem_informada.sql
+++ b/queries/models/br_rj_riodejaneiro_viagem_zirix/viagem_informada.sql
@@ -1,0 +1,33 @@
+{{
+  config(
+    materialized="incremental",
+    partition_by={
+      "field":"data",
+      "data_type":"date",
+      "granularity": "day"
+    },
+    incremental_strategy="insert_overwrite"
+  )
+}}
+
+SELECT
+  data_viagem AS data,
+  datetime_partida,
+  datetime_chegada,
+  datetime_processamento,
+  id_veiculo,
+  trip_id,
+  route_id,
+  shape_id,
+  servico,
+  CASE
+    WHEN sentido = 'I' THEN 'Ida'
+    WHEN sentido = 'V' THEN 'Volta'
+    ELSE sentido
+  END AS sentido,
+FROM
+  {{ ref("staging_viagem_informada") }}
+{% if is_incremental() %}
+  WHERE
+    data BETWEEN DATE("{{var('date_range_start')}}") AND DATE("{{var('date_range_end')}}")
+{% endif %}

--- a/queries/models/br_rj_riodejaneiro_viagem_zirix/viagem_informada.sql
+++ b/queries/models/br_rj_riodejaneiro_viagem_zirix/viagem_informada.sql
@@ -93,8 +93,4 @@ SELECT
   '{{ var("version") }}' AS versao,
   CURRENT_DATETIME("America/Sao_Paulo") as datetime_ultima_atualizacao
 FROM
-  {{ staging_viagem_informada }}
-{% if is_incremental() %}
-  WHERE
-    {{ incremental_filter }}
-{% endif %}
+  deduplicado

--- a/queries/models/sources.yml
+++ b/queries/models/sources.yml
@@ -146,3 +146,9 @@ sources:
 
     tables:
       - name: h3_res9
+
+  - name: br_rj_riodejaneiro_viagem_zirix_staging
+    database: rj-smtr-staging
+
+    tables:
+      - name: viagem_informada

--- a/queries/profiles.yml
+++ b/queries/profiles.yml
@@ -22,4 +22,4 @@ queries:
       project: rj-smtr
       threads: 1
       type: bigquery
-  target: prod
+  target: dev

--- a/queries/profiles.yml
+++ b/queries/profiles.yml
@@ -22,4 +22,4 @@ queries:
       project: rj-smtr
       threads: 1
       type: bigquery
-  target: dev
+  target: prod


### PR DESCRIPTION
# Pipelines
## Changelog - viagem_zirix

### [1.1.0] - 2024-06-26

#### Adicionado
- Cria flow `viagem_zirix_materializacao` para materialização dos dados de viagens de ônibus enviados pela API da Zirix 

# Queries

## Changelog - viagem_zirix

### [1.0.0] - 2024-06-26

#### Adicionado
- Cria modelos `staging_viagem_informada.sql` e `viagem_informada.sql` para tratamento dos dados de viagens de ônibus enviados pela API da Zirix