### PR TITLE
Bilhetagem - Adiciona coluna versao_app nas tabelas de gps do validador da Jaé

### DIFF
--- a/pipelines/migration/br_rj_riodejaneiro_bilhetagem/flows.py
+++ b/pipelines/migration/br_rj_riodejaneiro_bilhetagem/flows.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """
 Flows for br_rj_riodejaneiro_bilhetagem
+
+DBT: 2024-07-05
 """
 
 from copy import deepcopy

--- a/queries/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/queries/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - bilhetagem
 
+## [2.1.2] - 2024-07-05
+
+### Adicionado
+- Adiciona coluna `versao_app` nos modelos `gps_validador_aux.sql`, `gps_validador.sql` e `gps_validador_van.sql`
+
 ## [2.1.1] - 2024-06-19
 
 ### Corrigido

--- a/queries/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/queries/models/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [2.1.2] - 2024-07-05
 
 ### Adicionado
-- Adiciona coluna `versao_app` nos modelos `gps_validador_aux.sql`, `gps_validador.sql` e `gps_validador_van.sql`
+- Adiciona coluna `versao_app` nos modelos `gps_validador_aux.sql`, `gps_validador.sql` e `gps_validador_van.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/96)
 
 ## [2.1.1] - 2024-06-19
 

--- a/queries/models/br_rj_riodejaneiro_bilhetagem/gps_validador.sql
+++ b/queries/models/br_rj_riodejaneiro_bilhetagem/gps_validador.sql
@@ -33,6 +33,7 @@ SELECT
     sentido,
     estado_equipamento,
     temperatura,
+    versao_app,
     '{{ var("version") }}' as versao
 FROM
 (

--- a/queries/models/br_rj_riodejaneiro_bilhetagem/gps_validador_van.sql
+++ b/queries/models/br_rj_riodejaneiro_bilhetagem/gps_validador_van.sql
@@ -29,6 +29,7 @@ SELECT
     sentido,
     estado_equipamento,
     temperatura,
+    versao_app,
     '{{ var("version") }}' as versao
 FROM
 (

--- a/queries/models/br_rj_riodejaneiro_bilhetagem/schema.yml
+++ b/queries/models/br_rj_riodejaneiro_bilhetagem/schema.yml
@@ -187,6 +187,8 @@ models:
         description: "Validador aberto ou fechado no momento da transmissão"
       - name: temperatura
         description: "Temperatura do local, medida pelo sensor do validador (ºC)"
+      - name: versao_app
+        description: "Versão do Software do validador"
       - name: versao
         description: "Código de controle de versão do dado (SHA Github)"
   - name: gps_validador_van
@@ -234,6 +236,8 @@ models:
         description: "Validador aberto ou fechado no momento da transmissão"
       - name: temperatura
         description: "Temperatura do local, medida pelo sensor do validador (ºC)"
+      - name: versao_app
+        description: "Versão do Software do validador"
       - name: versao
         description: "Código de controle de versão do dado (SHA Github)"
   - name: passageiros_hora

--- a/queries/models/br_rj_riodejaneiro_bilhetagem_staging/gps_validador_aux.sql
+++ b/queries/models/br_rj_riodejaneiro_bilhetagem_staging/gps_validador_aux.sql
@@ -23,7 +23,8 @@ SELECT
     g.longitude_equipamento AS longitude,
     INITCAP(g.sentido_linha) AS sentido,
     g.estado_equipamento,
-    g.temperatura
+    g.temperatura,
+    g.versao_app
 FROM
     {{ ref("staging_gps_validador") }} g
 LEFT JOIN

--- a/queries/models/br_rj_riodejaneiro_bilhetagem_staging/staging_gps_validador.sql
+++ b/queries/models/br_rj_riodejaneiro_bilhetagem_staging/staging_gps_validador.sql
@@ -32,7 +32,7 @@ SELECT
     SAFE_CAST(JSON_VALUE(content, '$.qtd_venda_botao') AS FLOAT64) AS qtd_venda_botao,
     SAFE_CAST(JSON_VALUE(content, '$.sentido_linha') AS STRING) AS sentido_linha,
     SAFE_CAST(JSON_VALUE(content, '$.tarifa_linha') AS FLOAT64) AS tarifa_linha,
-    SAFE_CAST(JSON_VALUE(content, '$.versao_app') AS FLOAT64) AS versao_app,
+    SAFE_CAST(JSON_VALUE(content, '$.versao_app') AS STRING) AS versao_app,
     SAFE_CAST(JSON_VALUE(content, '$.temperatura') AS FLOAT64) AS temperatura
 FROM
     {{ source('br_rj_riodejaneiro_bilhetagem_staging', 'gps_validador') }}


### PR DESCRIPTION
# Changelog - bilhetagem

## [2.1.2] - 2024-07-05

### Adicionado
- Adiciona coluna `versao_app` nos modelos `gps_validador_aux.sql`, `gps_validador.sql` e `gps_validador_van.sql`