### PR TITLE
Materialização de `viagem_planejada` em D+0

### DIFF
--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - projeto_subsidio_sppo
 
+## [6.0.3] - 2024-08-01
+
+### Alterado
+
+- Alterados modelos `viagem_planejada.sql` e `subsidio_data_versao_efetiva.sql` para materializar sempre em D+0 e permitir acompanhamento pelos operadores ()
+
 ## [6.0.2] - 2024-04-22
 
 ### Adicionado

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Alterados modelos `viagem_planejada.sql` e `subsidio_data_versao_efetiva.sql` para materializar sempre em D+0 e permitir acompanhamento pelos operadores ()
+- Alterados modelos `viagem_planejada.sql` e `subsidio_data_versao_efetiva.sql` para materializar sempre em D+0 e permitir acompanhamento pelos operadores (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/125)
 
 ## [6.0.2] - 2024-04-22
 

--- a/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
+++ b/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
@@ -368,9 +368,9 @@ WITH
     (feed_version)
   WHERE
   {% if is_incremental() %}
-    data = DATE_SUB(DATE("{{ var("run_date") }}"), INTERVAL 1 DAY)
+    data BETWEEN DATE_SUB("{{ var('run_date') }}", INTERVAL 1 DAY) AND DATE("{{ var('run_date') }}")
   {% else %}
-    data <= DATE_SUB(DATE("{{ var("run_date") }}"), INTERVAL 1 DAY)
+    data <= DATE("{{ var('run_date') }}")
   {% endif %}
 )
 SELECT

--- a/queries/models/projeto_subsidio_sppo/viagem_planejada.sql
+++ b/queries/models/projeto_subsidio_sppo/viagem_planejada.sql
@@ -213,7 +213,7 @@ WITH
     {{ ref("subsidio_data_versao_efetiva") }}
     -- rj-smtr-dev.projeto_subsidio_sppo.subsidio_data_versao_efetiva
   WHERE
-    data = DATE_SUB("{{ var('run_date') }}", INTERVAL 1 DAY) )
+    data BETWEEN DATE_SUB("{{ var('run_date') }}", INTERVAL 1 DAY) AND DATE("{{ var('run_date') }}"))
 SELECT
   d.data,
   CASE


### PR DESCRIPTION
# Changelog - projeto_subsidio_sppo

## [6.0.3] - 2024-08-01

### Alterado

- Alterados modelos `viagem_planejada.sql` e `subsidio_data_versao_efetiva.sql` para materializar sempre em D+0 e permitir acompanhamento pelos operadores