### PR TITLE
Adicinona novos testes do subsidio

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/CHANGELOG.md
+++ b/pipelines/migration/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - projeto_subsidio_sppo
 
+## [1.0.4] - 2024-08-19
+
+### Adicionado
+
+- Adicionados os testes `Todas as viagens foram processadas com feed atualizado do GTFS` e `Todas as viagens foram atualizadas antes do processamento do subsídio` na constante `SUBSIDIO_SPPO_DATA_CHECKS_POS_LIST` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/147)
+
 ## [1.0.3] - 2024-08-08
 
 ### Adicionado

--- a/pipelines/migration/projeto_subsidio_sppo/constants.py
+++ b/pipelines/migration/projeto_subsidio_sppo/constants.py
@@ -500,11 +500,10 @@ class constants(Enum):  # pylint: disable=c0103
                     data,
                     datetime_ultima_atualizacao
                 FROM
-                    -- `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
-                    `rj-smtr-dev.dashboard_subsidio_sppo_novos_teste_subsidio.sumario_servico_dia_historico`
+                    `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
                 WHERE
                     DATA BETWEEN DATE("{start_timestamp}")
-                    AND DATE("{end_timestamp}")
+                    AND DATE("{end_timestamp}"))
                 SELECT
                 DISTINCT DATA
                 FROM

--- a/pipelines/migration/projeto_subsidio_sppo/constants.py
+++ b/pipelines/migration/projeto_subsidio_sppo/constants.py
@@ -493,18 +493,18 @@ class constants(Enum):  # pylint: disable=c0103
                     rj-smtr.projeto_subsidio_sppo.viagem_completa
                 WHERE
                     DATA >= "2024-04-01"
-                    AND DATA BETWEEN DATE("2024-07-01")
-                    AND DATE("2024-07-31")),
+                    AND DATA BETWEEN DATE("{start_timestamp}")
+                    AND DATE("{end_timestamp}")),
                 sumario_servico_dia_historico AS (
                 SELECT
                     data,
                     datetime_ultima_atualizacao
                 FROM
-                    -- `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia`
-                    `rj-smtr-dev.dashboard_subsidio_sppo_novos_teste_subsidio.sumario_servico_dia`
+                    -- `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
+                    `rj-smtr-dev.dashboard_subsidio_sppo_novos_teste_subsidio.sumario_servico_dia_historico`
                 WHERE
-                    DATA BETWEEN "2024-07-01"
-                    AND "2024-07-15" )
+                    DATA BETWEEN "{start_timestamp}"
+                    AND "{end_timestamp}" )
                 SELECT
                 DISTINCT DATA
                 FROM

--- a/pipelines/migration/projeto_subsidio_sppo/constants.py
+++ b/pipelines/migration/projeto_subsidio_sppo/constants.py
@@ -503,8 +503,8 @@ class constants(Enum):  # pylint: disable=c0103
                     -- `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
                     `rj-smtr-dev.dashboard_subsidio_sppo_novos_teste_subsidio.sumario_servico_dia_historico`
                 WHERE
-                    DATA BETWEEN "{start_timestamp}"
-                    AND "{end_timestamp}" )
+                    DATA BETWEEN DATE("{start_timestamp}")
+                    AND DATE("{end_timestamp}")
                 SELECT
                 DISTINCT DATA
                 FROM
@@ -542,9 +542,6 @@ class constants(Enum):  # pylint: disable=c0103
             },
             "Todos os dados de status dos veículos foram devidamente tratados": {
                 "test": "check_sppo_veiculo_dia",
-            },
-            "Todas as viagens foram processadas com feed atualizado do GTFS": {
-                "test": "check_viagem_completa",
             },
         }
     }
@@ -698,8 +695,11 @@ class constants(Enum):  # pylint: disable=c0103
             "Todas viagens com valor de subsídio por km não nulo e maior ou igual a zero": {
                 "expression": "subsidio_km IS NOT NULL AND subsidio_km >= 0",
             },
-            "Todas as viagens foram atualizadas antes do processamento do subsídio": {
+            "Todas viagens atualizadas antes do processamento do subsídio": {
                 "test": "teste_subsido_viagens_atualizadas"
+            },
+            "Todas viagens processadas com feed atualizado do GTFS": {
+                "test": "check_viagem_completa",
             },
         },
     }

--- a/pipelines/migration/projeto_subsidio_sppo/constants.py
+++ b/pipelines/migration/projeto_subsidio_sppo/constants.py
@@ -589,9 +589,6 @@ class constants(Enum):  # pylint: disable=c0103
             "Todos serviços com valor de subsídio pago não nulo e maior ou igual a zero": {
                 "expression": "valor_subsidio_pago IS NOT NULL AND valor_subsidio_pago >= 0",
             },
-            "Todas as viagens foram atualizadas antes do processamento do subsídio": {
-                "test": "teste_subsido_viagens_atualizadas"
-            },
         },
         "sumario_servico_dia_tipo_sem_glosa": {
             "Todas as somas dos tipos de quilometragem são equivalentes a quilometragem total": {
@@ -700,6 +697,9 @@ class constants(Enum):  # pylint: disable=c0103
             },
             "Todas viagens com valor de subsídio por km não nulo e maior ou igual a zero": {
                 "expression": "subsidio_km IS NOT NULL AND subsidio_km >= 0",
+            },
+            "Todas as viagens foram atualizadas antes do processamento do subsídio": {
+                "test": "teste_subsido_viagens_atualizadas"
             },
         },
     }

--- a/pipelines/migration/projeto_subsidio_sppo/constants.py
+++ b/pipelines/migration/projeto_subsidio_sppo/constants.py
@@ -501,7 +501,7 @@ class constants(Enum):  # pylint: disable=c0103
                     datetime_ultima_atualizacao
                 FROM
                     -- `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia`
-                    -- `rj-smtr-dev.dashboard_subsidio_sppo_novos_teste_subsidio.sumario_servico_dia`
+                    `rj-smtr-dev.dashboard_subsidio_sppo_novos_teste_subsidio.sumario_servico_dia`
                 WHERE
                     DATA BETWEEN "2024-07-01"
                     AND "2024-07-15" )

--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT 2024-08-19 
+DBT 2024-08-19
 """
 
 from prefect import Parameter, case, task

--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT 2024-08-19
+DBT 2024-08-19 
 """
 
 from prefect import Parameter, case, task

--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT 2024-08-13
+DBT 2024-08-19
 """
 
 from prefect import Parameter, case, task

--- a/queries/models/dashboard_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/dashboard_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - dashboard_subsidio_sppo
 
+## [7.0.1] - 2024-08-19
+
+## Adicionado
+
+- Adicionada coluna `datetime_ultima_atualizacao` na tabela `sumario_servico_dia_historico` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/147)
+
 ## [7.0.0] - 2024-07-31
 
 ### Alterado

--- a/queries/models/dashboard_subsidio_sppo/sumario_dia.sql
+++ b/queries/models/dashboard_subsidio_sppo/sumario_dia.sql
@@ -16,7 +16,8 @@ WITH
     MAX(distancia_total_planejada) AS distancia_total_planejada,
     NULL AS viagens_planejadas
   FROM
-    {{ ref("viagem_planejada") }} --``rj-smtr`.`projeto_subsidio_sppo`.`viagem_planejada`
+    -- {{ ref("viagem_planejada") }} 
+    `rj-smtr`.`projeto_subsidio_sppo`.`viagem_planejada`
   WHERE
     data >= "2022-06-01"
     AND data < DATE( "{{ var("DATA_SUBSIDIO_V2_INICIO") }}" )
@@ -34,7 +35,8 @@ WITH
     trip_id,
     COUNT(id_viagem) AS viagens_realizadas
   FROM
-    {{ ref("viagem_completa") }} -- `rj-smtr`.`projeto_subsidio_sppo`.`viagem_completa`
+    -- {{ ref("viagem_completa") }} 
+    `rj-smtr`.`projeto_subsidio_sppo`.`viagem_completa`
   WHERE
     data >= "2022-06-01"
     AND data < DATE( "{{ var("DATA_SUBSIDIO_V2_INICIO") }}" )
@@ -98,7 +100,8 @@ WITH
     SELECT
       *
     FROM
-      {{ ref("subsidio_data_versao_efetiva") }} -- `rj-smtr`.`projeto_subsidio_sppo`.`subsidio_data_versao_efetiva`
+      -- {{ ref("subsidio_data_versao_efetiva") }} 
+      `rj-smtr`.`projeto_subsidio_sppo`.`subsidio_data_versao_efetiva`
     WHERE
       data >= "2022-06-01"
       AND data < DATE( "{{ var("DATA_SUBSIDIO_V2_INICIO") }}" )) AS v

--- a/queries/models/dashboard_subsidio_sppo/sumario_dia.sql
+++ b/queries/models/dashboard_subsidio_sppo/sumario_dia.sql
@@ -16,8 +16,8 @@ WITH
     MAX(distancia_total_planejada) AS distancia_total_planejada,
     NULL AS viagens_planejadas
   FROM
-    -- {{ ref("viagem_planejada") }}
-    `rj-smtr`.`projeto_subsidio_sppo`.`viagem_planejada`
+    {{ ref("viagem_planejada") }}
+    -- `rj-smtr`.`projeto_subsidio_sppo`.`viagem_planejada`
   WHERE
     data >= "2022-06-01"
     AND data < DATE( "{{ var("DATA_SUBSIDIO_V2_INICIO") }}" )
@@ -35,8 +35,8 @@ WITH
     trip_id,
     COUNT(id_viagem) AS viagens_realizadas
   FROM
-    -- {{ ref("viagem_completa") }}
-    `rj-smtr`.`projeto_subsidio_sppo`.`viagem_completa`
+    {{ ref("viagem_completa") }}
+    -- `rj-smtr`.`projeto_subsidio_sppo`.`viagem_completa`
   WHERE
     data >= "2022-06-01"
     AND data < DATE( "{{ var("DATA_SUBSIDIO_V2_INICIO") }}" )
@@ -100,8 +100,8 @@ WITH
     SELECT
       *
     FROM
-      -- {{ ref("subsidio_data_versao_efetiva") }}
-      `rj-smtr`.`projeto_subsidio_sppo`.`subsidio_data_versao_efetiva`
+      {{ ref("subsidio_data_versao_efetiva") }}
+      -- `rj-smtr`.`projeto_subsidio_sppo`.`subsidio_data_versao_efetiva`
     WHERE
       data >= "2022-06-01"
       AND data < DATE( "{{ var("DATA_SUBSIDIO_V2_INICIO") }}" )) AS v

--- a/queries/models/dashboard_subsidio_sppo/sumario_dia.sql
+++ b/queries/models/dashboard_subsidio_sppo/sumario_dia.sql
@@ -16,7 +16,7 @@ WITH
     MAX(distancia_total_planejada) AS distancia_total_planejada,
     NULL AS viagens_planejadas
   FROM
-    -- {{ ref("viagem_planejada") }} 
+    -- {{ ref("viagem_planejada") }}
     `rj-smtr`.`projeto_subsidio_sppo`.`viagem_planejada`
   WHERE
     data >= "2022-06-01"
@@ -35,7 +35,7 @@ WITH
     trip_id,
     COUNT(id_viagem) AS viagens_realizadas
   FROM
-    -- {{ ref("viagem_completa") }} 
+    -- {{ ref("viagem_completa") }}
     `rj-smtr`.`projeto_subsidio_sppo`.`viagem_completa`
   WHERE
     data >= "2022-06-01"
@@ -100,7 +100,7 @@ WITH
     SELECT
       *
     FROM
-      -- {{ ref("subsidio_data_versao_efetiva") }} 
+      -- {{ ref("subsidio_data_versao_efetiva") }}
       `rj-smtr`.`projeto_subsidio_sppo`.`subsidio_data_versao_efetiva`
     WHERE
       data >= "2022-06-01"

--- a/queries/models/dashboard_subsidio_sppo/sumario_servico_dia.sql
+++ b/queries/models/dashboard_subsidio_sppo/sumario_servico_dia.sql
@@ -18,8 +18,8 @@ WITH
     servico,
     distancia_total_planejada AS km_planejada,
   FROM
-    {{ ref("viagem_planejada") }}
-    -- `rj-smtr`.`projeto_subsidio_sppo`.`viagem_planejada`
+    -- {{ ref("viagem_planejada") }}
+    `rj-smtr`.`projeto_subsidio_sppo`.`viagem_planejada`
   WHERE
     DATA BETWEEN DATE("{{ var("start_date") }}")
     AND DATE( "{{ var("end_date") }}" )
@@ -35,8 +35,8 @@ WITH
     id_viagem,
     distancia_planejada
  FROM
-    {{ ref("viagem_completa") }}
-    -- `rj-smtr`.`projeto_subsidio_sppo`.`viagem_completa`
+    -- {{ ref("viagem_completa") }}
+    `rj-smtr`.`projeto_subsidio_sppo`.`viagem_completa`
   WHERE
     DATA BETWEEN DATE("{{ var("start_date") }}")
     AND DATE( "{{ var("end_date") }}" ) ),
@@ -72,8 +72,8 @@ WITH
       distancia_planejada,
       subsidio_km
     FROM
-      {{ ref("viagens_remuneradas") }}
-      -- `rj-smtr.dashboard_subsidio_sppo.viagens_remuneradas`
+      -- {{ ref("viagens_remuneradas") }}
+      `rj-smtr.dashboard_subsidio_sppo.viagens_remuneradas`
     WHERE
       DATA BETWEEN DATE("{{ var("start_date") }}")
       AND DATE( "{{ var("end_date") }}" )

--- a/queries/models/dashboard_subsidio_sppo/sumario_servico_dia.sql
+++ b/queries/models/dashboard_subsidio_sppo/sumario_servico_dia.sql
@@ -18,8 +18,8 @@ WITH
     servico,
     distancia_total_planejada AS km_planejada,
   FROM
-    -- {{ ref("viagem_planejada") }}
-    `rj-smtr`.`projeto_subsidio_sppo`.`viagem_planejada`
+    {{ ref("viagem_planejada") }}
+    -- `rj-smtr`.`projeto_subsidio_sppo`.`viagem_planejada`
   WHERE
     DATA BETWEEN DATE("{{ var("start_date") }}")
     AND DATE( "{{ var("end_date") }}" )
@@ -35,8 +35,8 @@ WITH
     id_viagem,
     distancia_planejada
  FROM
-    -- {{ ref("viagem_completa") }}
-    `rj-smtr`.`projeto_subsidio_sppo`.`viagem_completa`
+    {{ ref("viagem_completa") }}
+    -- `rj-smtr`.`projeto_subsidio_sppo`.`viagem_completa`
   WHERE
     DATA BETWEEN DATE("{{ var("start_date") }}")
     AND DATE( "{{ var("end_date") }}" ) ),
@@ -72,8 +72,8 @@ WITH
       distancia_planejada,
       subsidio_km
     FROM
-      -- {{ ref("viagens_remuneradas") }}
-      `rj-smtr.dashboard_subsidio_sppo.viagens_remuneradas`
+      {{ ref("viagens_remuneradas") }}
+      -- `rj-smtr.dashboard_subsidio_sppo.viagens_remuneradas`
     WHERE
       DATA BETWEEN DATE("{{ var("start_date") }}")
       AND DATE( "{{ var("end_date") }}" )

--- a/queries/models/dashboard_subsidio_sppo/sumario_servico_dia_historico.sql
+++ b/queries/models/dashboard_subsidio_sppo/sumario_servico_dia_historico.sql
@@ -140,7 +140,8 @@ dados_completos AS (
       sumario_glosa_suspensa )
 )
 SELECT
-  *
+  *,
+  CURRENT_DATETIME("America/Sao_Paulo") as datetime_ultima_atualizacao
 FROM
   dados_completos
 {% if is_incremental() %}


### PR DESCRIPTION
# Changelog - projeto_subsidio_sppo

## [1.0.4] - 2024-08-19

### Adicionado

- - Adicionados os testes `Todas as viagens foram processadas com feed atualizado do GTFS` e `Todas as viagens foram atualizadas antes do processamento do subsídio` na constante `SUBSIDIO_SPPO_DATA_CHECKS_POS_LIST`

# Changelog - dashboard_subsidio_sppo

## [7.0.1] - 2024-08-19

## Adicionado

- Adicionada coluna `datetime_ultima_atualizacao` na tabela `sumario_servico_dia_historico`