### PR TITLE
Adiciona tabela do subsídio no exclude da materialização das tabelas do GPS do validador

### DIFF
--- a/pipelines/migration/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - br_rj_riodejaneiro_bilhetagem
 
+## [1.3.1] - 2024-08-19
+
+### Alterado
+
+- Adiciona tabela do subsídio no exclude da materialização das tabelas do GPS do validador.
+
 ## [1.3.0] - 2024-08-05
 
 ### Adicionado

--- a/pipelines/migration/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Adiciona tabela do subsídio no exclude da materialização das tabelas do GPS do validador.
+- Adiciona tabela do subsídio no exclude da materialização das tabelas do GPS do validador (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/150)
 
 ## [1.3.0] - 2024-08-05
 

--- a/pipelines/migration/br_rj_riodejaneiro_bilhetagem/constants.py
+++ b/pipelines/migration/br_rj_riodejaneiro_bilhetagem/constants.py
@@ -522,7 +522,8 @@ aux_retorno_ordem_pagamento",
         "dataset_id": smtr_constants.BILHETAGEM_DATASET_ID.value,
         "upstream": True,
         "downstream": True,
-        "exclude": f"{BILHETAGEM_EXCLUDE} veiculo_validacao veiculo_indicadores_dia",
+        "exclude": f"{BILHETAGEM_EXCLUDE} veiculo_validacao veiculo_indicadores_dia \
+viagem_transacao+",
         "dbt_vars": {
             "date_range": {
                 "table_run_datetime_column_name": "datetime_captura",

--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -37,6 +37,7 @@ vars:
   sppo_registros_staging: "rj-smtr-staging.br_rj_riodejaneiro_onibus_gps_staging.registros"
   sppo_realocacao_staging: "rj-smtr-staging.br_rj_riodejaneiro_onibus_gps_staging.realocacao"
   data_inicio_realocacao: "2022-11-15"
+  fifteen_minutes: ""
 
   # Parametros de intersecção do ônibus com rota
   ## Tamanho do buffer da rota


### PR DESCRIPTION
# Changelog - br_rj_riodejaneiro_bilhetagem

## [1.3.1] - 2024-08-19

### Alterado

- Adiciona tabela do subsídio no exclude da materialização das tabelas do GPS do validador.