### PR TITLE
HOTFIX GPS Zirix - Corrige table_id do get_materialization_date_range

### DIFF
--- a/pipelines/migration/br_rj_riodejaneiro_onibus_gps_zirix/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_onibus_gps_zirix/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog - br_rj_riodejaneiro_onibus_gps_zirix
 
-## [1.0.0] - 2024-08-26
+## [1.0.0] - 2024-09-02
 
 ### Corrigido
-- Corrige table_id na task `get_materialization_date_range` no flow `materialize_sppo_zirix` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/164)
+- Corrige table_id na task `get_materialization_date_range` no flow `materialize_sppo_zirix` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/181)

--- a/pipelines/migration/br_rj_riodejaneiro_onibus_gps_zirix/flows.py
+++ b/pipelines/migration/br_rj_riodejaneiro_onibus_gps_zirix/flows.py
@@ -134,7 +134,7 @@ with Flow(
     # Set specific run parameters #
     date_range = get_materialization_date_range(
         dataset_id=dataset_id,
-        table_id=table_id,
+        table_id="gps_sppo",
         raw_dataset_id=raw_dataset_id,
         raw_table_id=raw_table_id,
         table_run_datetime_column_name="timestamp_gps",


### PR DESCRIPTION
# Changelog - br_rj_riodejaneiro_onibus_gps_zirix

## [1.0.0] - 2024-09-02

### Corrigido
- Corrige table_id na task `get_materialization_date_range` no flow `materialize_sppo_zirix`