### PR TITLE
Bilhetagem - Filtra integrações com 2 ou mais transações `BRT` na tabela `integracao_nao_realizada`

### DIFF
--- a/pipelines/migration/br_rj_riodejaneiro_bilhetagem/flows.py
+++ b/pipelines/migration/br_rj_riodejaneiro_bilhetagem/flows.py
@@ -2,7 +2,7 @@
 """
 Flows for br_rj_riodejaneiro_bilhetagem
 
-DBT: 2024-08-26
+DBT: 2024-09-04
 """
 
 from copy import deepcopy

--- a/queries/models/validacao_dados_jae/CHANGELOG.md
+++ b/queries/models/validacao_dados_jae/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - validacao_dados_jae
 
+## [1.1.3] - 2024-09-04
+
+### Alterado
+  - Cria filtro para remover integrações com 2 ou mais transações do modo `BRT` no modelo `integracao_nao_realizada.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/185)
+
 ## [1.1.2] - 2024-08-27
 
 ### Corrigido

--- a/queries/models/validacao_dados_jae/CHANGELOG.md
+++ b/queries/models/validacao_dados_jae/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## [1.1.3] - 2024-09-04
 
 ### Alterado
-  - Cria filtro para remover integrações com 2 ou mais transações do modo `BRT` no modelo `integracao_nao_realizada.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/185)
+  - Modelo `integracao_nao_realizada.sql`:
+    - Soma 1 na coluna `sequencia_integracao` para padronizar em relação a tabela `integracao` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/185)
+    - Cria filtro para remover integrações com 2 ou mais transações do modo `BRT` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/185)
 
 ## [1.1.2] - 2024-08-27
 

--- a/queries/models/validacao_dados_jae/integracao_nao_realizada.sql
+++ b/queries/models/validacao_dados_jae/integracao_nao_realizada.sql
@@ -57,7 +57,7 @@
 
 WITH matriz AS (
   SELECT
-    string_agg(modo order by sequencia_integracao) AS sequencia_valida
+    STRING_AGG(modo order by sequencia_integracao) AS sequencia_valida
   FROM
     {{ ref("matriz_integracao") }}
     -- `rj-smtr.br_rj_riodejaneiro_bilhetagem.matriz_integracao`
@@ -207,7 +207,7 @@ melted AS (
     modo,
     SPLIT(servico_sentido, '_')[0] AS id_servico_jae,
     SPLIT(servico_sentido, '_')[1] AS sentido,
-    countif(modo = "BRT") OVER(PARTITION BY id_integracao) > 1 AS indicador_transferencia
+    COUNTIF(modo = "BRT") OVER(PARTITION BY id_integracao) > 1 AS indicador_transferencia
   FROM
     integracoes_validas,
     UNNEST(


### PR DESCRIPTION
# Changelog - validacao_dados_jae

## [1.1.3] - 2024-09-04

### Alterado
  - Modelo `integracao_nao_realizada.sql`:
    - Soma 1 na coluna `sequencia_integracao` para padronizar em relação a tabela `integracao` 
    - Cria filtro para remover integrações com 2 ou mais transações do modo `BRT`