### PR TITLE
Adiciona captura do GCS na pipeline de subida do GTFS

### DIFF
--- a/pipelines/migration/CHANGELOG.md
+++ b/pipelines/migration/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - migration
 
+## [1.0.2] - 2024-09-11
+
+### Adicionado
+
+- Adicionado log à função `get_upload_storage_blob` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/206)
+
 ## [1.0.1] - 2024-08-29
 
 ### Adicionado

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog - gtfs
 
+## [1.1.0] - 2024-09-11
+
+### Alterado
+
+- Criada feature para subida manual com base nos arquivos no GCS (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/206)
+- Função `get_raw_drive_files` transformada em `get_raw_gtfs_files` e adaptada para capturar os arquivos tanto através do Google Drive quanto através do GCS por meio do novo parâmetro `upload_from_gcs` do flow `gtfs_captura_nova` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/206)
+- Funções `processa_ordem_servico`, `processa_ordem_servico_trajeto_alternativo` e `processa_ordem_servico_faixa_horaria` ajustadas para considerar a coluna `tipo_os` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/206)
+- Incorporadas outros nomes de colunas a serem renomeados na função `processa_ordem_servico_faixa_horaria`, bem como corrigido o tratamento de colunas ausentes (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/206)
+
 ## [1.0.8] - 2024-09-06
 
 ### Adicionado

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/flows.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/flows.py
@@ -26,7 +26,7 @@ from pipelines.constants import constants
 from pipelines.migration.br_rj_riodejaneiro_gtfs.tasks import (
     get_last_capture_os,
     get_os_info,
-    get_raw_drive_files,
+    get_raw_gtfs_files,
     update_last_captured_os,
 )
 from pipelines.migration.tasks import (
@@ -100,6 +100,7 @@ from pipelines.tasks import get_scheduled_timestamp, parse_timestamp_to_string
 # )
 
 with Flow("SMTR: GTFS - Captura/Tratamento") as gtfs_captura_nova:
+    upload_from_gcs = Parameter("upload_from_gcs", default=False)
     materialize_only = Parameter("materialize_only", default=False)
     regular_sheet_index = Parameter("regular_sheet_index", default=None)
     data_versao_gtfs_param = Parameter("data_versao_gtfs", default=None)
@@ -145,10 +146,11 @@ with Flow("SMTR: GTFS - Captura/Tratamento") as gtfs_captura_nova:
                 filename=unmapped(filename),
             )
 
-            raw_filepaths, primary_keys = get_raw_drive_files(
+            raw_filepaths, primary_keys = get_raw_gtfs_files(
                 os_control=os_control,
                 local_filepath=local_filepaths,
                 regular_sheet_index=regular_sheet_index,
+                upload_from_gcs=upload_from_gcs
             )
 
             transform_raw_to_nested_structure_results = transform_raw_to_nested_structure.map(

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/flows.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/flows.py
@@ -233,6 +233,10 @@ gtfs_captura_nova.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
 gtfs_captura_nova.run_config = KubernetesRun(
     image=constants.DOCKER_IMAGE.value,
     labels=[constants.RJ_SMTR_AGENT_LABEL.value],
+    cpu_limit="1000m",
+    memory_limit="4600Mi",
+    cpu_request="500m",
+    memory_request="1000Mi",
 )
 gtfs_captura_nova.state_handlers = [
     handler_inject_bd_credentials,

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/flows.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/flows.py
@@ -150,7 +150,7 @@ with Flow("SMTR: GTFS - Captura/Tratamento") as gtfs_captura_nova:
                 os_control=os_control,
                 local_filepath=local_filepaths,
                 regular_sheet_index=regular_sheet_index,
-                upload_from_gcs=upload_from_gcs
+                upload_from_gcs=upload_from_gcs,
             )
 
             transform_raw_to_nested_structure_results = transform_raw_to_nested_structure.map(

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/tasks.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/tasks.py
@@ -2,6 +2,7 @@
 """
 Tasks for gtfs
 """
+import io
 import os
 import zipfile
 from datetime import datetime
@@ -179,14 +180,18 @@ def get_raw_gtfs_files(
         log("Baixando arquivos através do GCS")
 
         # Baixa planilha de OS
-        file_bytes_os = get_upload_storage_blob(
-            dataset_id=constants.GTFS_DATASET_ID.value, filename="os"
-        ).download_as_bytes()
+        file_bytes_os = io.BytesIO(
+            get_upload_storage_blob(
+                dataset_id=constants.GTFS_DATASET_ID.value, filename="os"
+            ).download_as_bytes()
+        )
 
         # Baixa GTFS
-        file_bytes_gtfs = get_upload_storage_blob(
-            dataset_id=constants.GTFS_DATASET_ID.value, filename="gtfs"
-        ).download_as_bytes()
+        file_bytes_gtfs = io.BytesIO(
+            get_upload_storage_blob(
+                dataset_id=constants.GTFS_DATASET_ID.value, filename="gtfs"
+            ).download_as_bytes()
+        )
 
     else:
         log("Baixando arquivos através do Google Drive")

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/tasks.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/tasks.py
@@ -24,7 +24,7 @@ from pipelines.migration.br_rj_riodejaneiro_gtfs.utils import (
     processa_ordem_servico_faixa_horaria,
     processa_ordem_servico_trajeto_alternativo,
 )
-from pipelines.migration.utils import save_raw_local_func
+from pipelines.migration.utils import save_raw_local_func, get_upload_storage_blob
 
 
 @task
@@ -153,13 +153,14 @@ def get_os_info(last_captured_os: str = None, data_versao_gtfs: str = None) -> d
 
 
 @task(nout=2)
-def get_raw_drive_files(os_control, local_filepath: list, regular_sheet_index: int = None):
+def get_raw_gtfs_files(os_control, local_filepath: list, regular_sheet_index: int = None, upload_from_gcs: bool = False):
     """
-    Downloads raw files from Google Drive and processes them.
+    Downloads raw files and processes them.
 
     Args:
         os_control (dict): A dictionary containing information about the OS (Ordem de Serviço).
         local_filepath (list): A list of local file paths where the downloaded files will be saved.
+
 
     Returns:
         raw_filepaths (list): A list of file paths where the downloaded raw files are saved.
@@ -170,22 +171,34 @@ def get_raw_drive_files(os_control, local_filepath: list, regular_sheet_index: i
 
     log(f"Baixando arquivos: {os_control}")
 
-    # Autenticar usando o arquivo de credenciais
-    credentials = service_account.Credentials.from_service_account_file(
-        filename=os.environ["GOOGLE_APPLICATION_CREDENTIALS"],
-        scopes=["https://www.googleapis.com/auth/drive.readonly"],
-    )
+    if upload_from_gcs:
+        log(f"Baixando arquivos através do GCS")
 
-    # Criar o serviço da API Google Drive e Google Sheets
-    drive_service = build("drive", "v3", credentials=credentials)
+        # Baixa planilha de OS
+        file_bytes_os = get_upload_storage_blob(dataset_id="br_rj_riodejaneiro_gtfs", filename="os.xlsx").download_as_bytes()
 
-    # Baixa planilha de OS
-    file_link = os_control["Link da OS"]
-    file_bytes_os = download_xlsx(file_link=file_link, drive_service=drive_service)
+        # Baixa GTFS
+        file_bytes_gtfs = get_upload_storage_blob(dataset_id="br_rj_riodejaneiro_gtfs", filename="gtfs.zip").download_as_bytes()
 
-    # Baixa GTFS
-    file_link = os_control["Link do GTFS"]
-    file_bytes_gtfs = download_file(file_link=file_link, drive_service=drive_service)
+    else:
+        log(f"Baixando arquivos através do Google Drive")
+        
+        # Autenticar usando o arquivo de credenciais
+        credentials = service_account.Credentials.from_service_account_file(
+            filename=os.environ["GOOGLE_APPLICATION_CREDENTIALS"],
+            scopes=["https://www.googleapis.com/auth/drive.readonly"],
+        )
+
+        # Criar o serviço da API Google Drive e Google Sheets
+        drive_service = build("drive", "v3", credentials=credentials)
+
+        # Baixa planilha de OS
+        file_link = os_control["Link da OS"]
+        file_bytes_os = download_xlsx(file_link=file_link, drive_service=drive_service)
+
+        # Baixa GTFS
+        file_link = os_control["Link do GTFS"]
+        file_bytes_gtfs = download_file(file_link=file_link, drive_service=drive_service)
 
     # Salva os nomes das planilhas
     sheetnames = xl.load_workbook(file_bytes_os).sheetnames

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/tasks.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/tasks.py
@@ -24,7 +24,7 @@ from pipelines.migration.br_rj_riodejaneiro_gtfs.utils import (
     processa_ordem_servico_faixa_horaria,
     processa_ordem_servico_trajeto_alternativo,
 )
-from pipelines.migration.utils import save_raw_local_func, get_upload_storage_blob
+from pipelines.migration.utils import get_upload_storage_blob, save_raw_local_func
 
 
 @task
@@ -153,7 +153,9 @@ def get_os_info(last_captured_os: str = None, data_versao_gtfs: str = None) -> d
 
 
 @task(nout=2)
-def get_raw_gtfs_files(os_control, local_filepath: list, regular_sheet_index: int = None, upload_from_gcs: bool = False):
+def get_raw_gtfs_files(
+    os_control, local_filepath: list, regular_sheet_index: int = None, upload_from_gcs: bool = False
+):
     """
     Downloads raw files and processes them.
 
@@ -175,14 +177,18 @@ def get_raw_gtfs_files(os_control, local_filepath: list, regular_sheet_index: in
         log(f"Baixando arquivos através do GCS")
 
         # Baixa planilha de OS
-        file_bytes_os = get_upload_storage_blob(dataset_id="br_rj_riodejaneiro_gtfs", filename="os.xlsx").download_as_bytes()
+        file_bytes_os = get_upload_storage_blob(
+            dataset_id="br_rj_riodejaneiro_gtfs", filename="os.xlsx"
+        ).download_as_bytes()
 
         # Baixa GTFS
-        file_bytes_gtfs = get_upload_storage_blob(dataset_id="br_rj_riodejaneiro_gtfs", filename="gtfs.zip").download_as_bytes()
+        file_bytes_gtfs = get_upload_storage_blob(
+            dataset_id="br_rj_riodejaneiro_gtfs", filename="gtfs.zip"
+        ).download_as_bytes()
 
     else:
         log(f"Baixando arquivos através do Google Drive")
-        
+
         # Autenticar usando o arquivo de credenciais
         credentials = service_account.Credentials.from_service_account_file(
             filename=os.environ["GOOGLE_APPLICATION_CREDENTIALS"],

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/utils.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/utils.py
@@ -484,6 +484,7 @@ def processa_ordem_servico_faixa_horaria(sheetnames, file_bytes, local_filepath,
         "Quilometragem entre  24h e 03h (dia seguinte) — Ponto Facultativo": "quilometragem_entre_24h_e_03h_diaseguinte_ponto_facultativo",  # noqa
     }
 
+    ordem_servico_faixa_horaria.columns = ordem_servico_faixa_horaria.columns.str.replace("\n", "")
     ordem_servico_faixa_horaria = ordem_servico_faixa_horaria.rename(columns=fh_columns)
 
     columns_in_dataframe = set(ordem_servico_faixa_horaria.columns)

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/utils.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/utils.py
@@ -278,7 +278,7 @@ def processa_ordem_servico(
     quadro["extensao_ida"] = quadro["extensao_ida"] / 1000
     quadro["extensao_volta"] = quadro["extensao_volta"] / 1000
 
-    if "tipo_os" not in quadro_geral.columns:
+    if "tipo_os" not in quadro.columns:
         quadro["tipo_os"] = "Regular"
 
     quadro_geral = pd.concat([quadro_geral, quadro])

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/utils.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/utils.py
@@ -278,6 +278,9 @@ def processa_ordem_servico(
     quadro["extensao_ida"] = quadro["extensao_ida"] / 1000
     quadro["extensao_volta"] = quadro["extensao_volta"] / 1000
 
+    if "tipo_os" not in quadro_geral.columns:
+        quadro["tipo_os"] = "Regular"
+
     quadro_geral = pd.concat([quadro_geral, quadro])
 
     # Verificações
@@ -366,6 +369,9 @@ def processa_ordem_servico_trajeto_alternativo(
     ordem_servico_trajeto_alternativo = ordem_servico_trajeto_alternativo.rename(
         columns=alt_columns
     )
+
+    if "tipo_os" not in ordem_servico_trajeto_alternativo.columns:
+        ordem_servico_trajeto_alternativo["tipo_os"] = "Regular"
 
     columns_in_dataframe = set(ordem_servico_trajeto_alternativo.columns)
     columns_in_values = set(list(alt_columns.values()))
@@ -458,6 +464,8 @@ def processa_ordem_servico_faixa_horaria(sheetnames, file_bytes, local_filepath,
         "Quilometragem entre 21h e 24h — Dias Úteis": "quilometragem_entre_21h_e_24h_dias_uteis",
         "Partidas entre 24h e 03h (dia seguinte) — Dias Úteis": "partidas_entre_24h_e_03h_diaseguinte_dias_uteis",  # noqa
         "Quilometragem entre 24h e 03h (dia seguinte) — Dias Úteis": "quilometragem_entre_24h_e_03h_diaseguinte_dias_uteis",  # noqa
+        "Partidas entre 00h e 03h — Sábado": "partidas_entre_00h_e_03h_sabado",
+        "Quilometragem entre 00h e 03h — Sábado": "quilometragem_entre_00h_e_03h_sabado",
         "Partidas entre 03h e 12h — Sábado": "partidas_entre_03h_e_12h_sabado",
         "Quilometragem entre 03h e 12h — Sábado": "quilometragem_entre_03h_e_12h_sabado",
         "Partidas entre 12h e 21h — Sábado": "partidas_entre_12h_e_21h_sabado",
@@ -466,6 +474,8 @@ def processa_ordem_servico_faixa_horaria(sheetnames, file_bytes, local_filepath,
         "Quilometragem entre 21h e 24h — Sábado": "quilometragem_entre_21h_e_24h_sabado",
         "Partidas entre 24h e 03h (dia seguinte) — Sábado": "partidas_entre_24h_e_03h_diaseguinte_sabado",  # noqa
         "Quilometragem entre 24h e 03h (dia seguinte) — Sábado": "quilometragem_entre_24h_e_03h_diaseguinte_sabado",  # noqa
+        "Partidas entre 00h e 03h — Domingo": "partidas_entre_00h_e_03h_domingo",
+        "Quilometragem entre 00h e 03h — Domingo": "quilometragem_entre_00h_e_03h_domingo",
         "Partidas entre 03h e 12h — Domingo": "partidas_entre_03h_e_12h_domingo",
         "Quilometragem entre 03h e 12h — Domingo": "quilometragem_entre_03h_e_12h_domingo",
         "Partidas entre 12h e 21h — Domingo": "partidas_entre_12h_e_21h_domingo",
@@ -482,18 +492,67 @@ def processa_ordem_servico_faixa_horaria(sheetnames, file_bytes, local_filepath,
         "Quilometragem entre 21h e 24h — Ponto Facultativo": "quilometragem_entre_21h_e_24h_ponto_facultativo",  # noqa
         "Partidas entre 24h e 03h (dia seguinte) — Ponto Facultativo": "partidas_entre_24h_e_03h_diaseguinte_ponto_facultativo",  # noqa
         "Quilometragem entre 24h e 03h (dia seguinte) — Ponto Facultativo": "quilometragem_entre_24h_e_03h_diaseguinte_ponto_facultativo",  # noqa
+        "Partidas entre 00h e 03h (Dias Úteis)": "partidas_entre_00h_e_03h_dias_uteis",
+        "Quilometragem entre 00h e 03h (Dias Úteis)": "quilometragem_entre_00h_e_03h_dias_uteis",
+        "Partidas entre 03h e 12h (Dias Úteis)": "partidas_entre_03h_e_12h_dias_uteis",
+        "Quilometragem entre 03h e 12h (Dias Úteis)": "quilometragem_entre_03h_e_12h_dias_uteis",
+        "Partidas entre 12h e 21h (Dias Úteis)": "partidas_entre_12h_e_21h_dias_uteis",
+        "Quilometragem entre 12h e 21h (Dias Úteis)": "quilometragem_entre_12h_e_21h_dias_uteis",
+        "Partidas entre 21h e 24h (Dias Úteis)": "partidas_entre_21h_e_24h_dias_uteis",
+        "Quilometragem entre 21h e 24h (Dias Úteis)": "quilometragem_entre_21h_e_24h_dias_uteis",
+        "Partidas entre 24h e 03h (dia seguinte) (Dias Úteis)": "partidas_entre_24h_e_03h_diaseguinte_dias_uteis",  # noqa
+        "Quilometragem entre 24h e 03h (dia seguinte) (Dias Úteis)": "quilometragem_entre_24h_e_03h_diaseguinte_dias_uteis",  # noqa
+        "Partidas entre 00h e 03h (Sábado)": "partidas_entre_00h_e_03h_sabado",
+        "Quilometragem entre 00h e 03h (Sábado)": "quilometragem_entre_00h_e_03h_sabado",
+        "Partidas entre 03h e 12h (Sábado)": "partidas_entre_03h_e_12h_sabado",
+        "Quilometragem entre 03h e 12h (Sábado)": "quilometragem_entre_03h_e_12h_sabado",
+        "Partidas entre 12h e 21h (Sábado)": "partidas_entre_12h_e_21h_sabado",
+        "Quilometragem entre 12h e 21h (Sábado)": "quilometragem_entre_12h_e_21h_sabado",
+        "Partidas entre 21h e 24h (Sábado)": "partidas_entre_21h_e_24h_sabado",
+        "Quilometragem entre 21h e 24h (Sábado)": "quilometragem_entre_21h_e_24h_sabado",
+        "Partidas entre 24h e 03h (dia seguinte) (Sábado)": "partidas_entre_24h_e_03h_diaseguinte_sabado",  # noqa
+        "Quilometragem entre 24h e 03h (dia seguinte) (Sábado)": "quilometragem_entre_24h_e_03h_diaseguinte_sabado",  # noqa
+        "Partidas entre 00h e 03h (Domingo)": "partidas_entre_00h_e_03h_domingo",
+        "Quilometragem entre 00h e 03h (Domingo)": "quilometragem_entre_00h_e_03h_domingo",
+        "Partidas entre 03h e 12h (Domingo)": "partidas_entre_03h_e_12h_domingo",
+        "Quilometragem entre 03h e 12h (Domingo)": "quilometragem_entre_03h_e_12h_domingo",
+        "Partidas entre 12h e 21h (Domingo)": "partidas_entre_12h_e_21h_domingo",
+        "Quilometragem entre 12h e 21h (Domingo)": "quilometragem_entre_12h_e_21h_domingo",
+        "Partidas entre 21h e 24h (Domingo)": "partidas_entre_21h_e_24h_domingo",
+        "Quilometragem entre 21h e 24h (Domingo)": "quilometragem_entre_21h_e_24h_domingo",
+        "Partidas entre 24h e 03h (dia seguinte) (Domingo)": "partidas_entre_24h_e_03h_diaseguinte_domingo",  # noqa
+        "Quilometragem entre 24h e 03h (dia seguinte) (Domingo)": "quilometragem_entre_24h_e_03h_diaseguinte_domingo",  # noqa
+        "Partidas entre 03h e 12h (Ponto Facultativo)": "partidas_entre_03h_e_12h_ponto_facultativo",  # noqa
+        "Quilometragem entre 03h e 12h (Ponto Facultativo)": "quilometragem_entre_03h_e_12h_ponto_facultativo",  # noqa
+        "Partidas entre 12h e 21h (Ponto Facultativo)": "partidas_entre_12h_e_21h_ponto_facultativo",  # noqa
+        "Quilometragem entre 12h e 21h (Ponto Facultativo)": "quilometragem_entre_12h_e_21h_ponto_facultativo",  # noqa
+        "Partidas entre 21h e 24h (Ponto Facultativo)": "partidas_entre_21h_e_24h_ponto_facultativo",  # noqa
+        "Quilometragem entre 21h e 24h (Ponto Facultativo)": "quilometragem_entre_21h_e_24h_ponto_facultativo",  # noqa
+        "Partidas entre 24h e 03h (dia seguinte) (Ponto Facultativo)": "partidas_entre_24h_e_03h_diaseguinte_ponto_facultativo",  # noqa
+        "Quilometragem entre 24h e 03h (dia seguinte) (Ponto Facultativo)": "quilometragem_entre_24h_e_03h_diaseguinte_ponto_facultativo",  # noqa
         "tipo_os": "tipo_os",
     }
 
     ordem_servico_faixa_horaria.columns = ordem_servico_faixa_horaria.columns.str.replace("\n", " ")
     ordem_servico_faixa_horaria = ordem_servico_faixa_horaria.rename(columns=fh_columns)
 
-    columns_in_dataframe = set(ordem_servico_faixa_horaria.columns)
-    columns_in_values = set(list(fh_columns.values()))
+    if "tipo_os" not in ordem_servico_faixa_horaria.columns:
+        ordem_servico_faixa_horaria["tipo_os"] = "Regular"
 
+    aux_columns_in_dataframe = set(ordem_servico_faixa_horaria.columns)
+    columns_in_values = set(list(fh_columns.values()))
+    aux_missing_columns = columns_in_values - aux_columns_in_dataframe
+
+    for coluna in aux_missing_columns:
+        if "ponto_facultativo" in coluna:
+            ordem_servico_faixa_horaria[coluna] = 0
+
+    log(f"colunas anexo: {ordem_servico_faixa_horaria.columns}")
+
+    columns_in_dataframe = set(ordem_servico_faixa_horaria.columns)
+    missing_columns = columns_in_values - columns_in_dataframe
     all_columns_present = columns_in_dataframe.issubset(columns_in_values)
     no_duplicate_columns = len(columns_in_dataframe) == len(ordem_servico_faixa_horaria.columns)
-    missing_columns = columns_in_values - columns_in_dataframe
 
     log(
         f"All columns present: {all_columns_present}/"
@@ -501,11 +560,8 @@ def processa_ordem_servico_faixa_horaria(sheetnames, file_bytes, local_filepath,
         f"Missing columns: {missing_columns}"
     )
 
-    for coluna in missing_columns:
-        ordem_servico_faixa_horaria[coluna] = 0
-
-    if not no_duplicate_columns:
-        raise Exception("Duplicated columns in ordem_servico_faixa_horaria")
+    if not all_columns_present or not no_duplicate_columns:
+        raise Exception("Missing or duplicated columns in ordem_servico_faixa_horaria")
 
     local_file_path = list(filter(lambda x: "ordem_servico_faixa_horaria" in x, local_filepath))[0]
     ordem_servico_faixa_horaria_csv = ordem_servico_faixa_horaria.to_csv(index=False)

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/utils.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/utils.py
@@ -278,9 +278,6 @@ def processa_ordem_servico(
     quadro["extensao_ida"] = quadro["extensao_ida"] / 1000
     quadro["extensao_volta"] = quadro["extensao_volta"] / 1000
 
-    if "tipo_os" not in quadro_geral.columns:
-        quadro["tipo_os"] = "Regular"
-
     quadro_geral = pd.concat([quadro_geral, quadro])
 
     # Verificações
@@ -370,9 +367,6 @@ def processa_ordem_servico_trajeto_alternativo(
         columns=alt_columns
     )
 
-    if "tipo_os" not in ordem_servico_trajeto_alternativo.columns:
-        ordem_servico_trajeto_alternativo["tipo_os"] = "Regular"
-
     columns_in_dataframe = set(ordem_servico_trajeto_alternativo.columns)
     columns_in_values = set(list(alt_columns.values()))
 
@@ -454,48 +448,45 @@ def processa_ordem_servico_faixa_horaria(sheetnames, file_bytes, local_filepath,
     fh_columns = {
         "Serviço": "servico",
         "Consórcio": "consorcio",
-        "Partidas entre  00h e 03h — Dias Úteis": "partidas_entre_00h_e_03h_dias_uteis",
-        "Quilometragem entre  00h e 03h — Dias Úteis": "quilometragem_entre_00h_e_03h_dias_uteis",
-        "Partidas entre  03h e 12h — Dias Úteis": "partidas_entre_03h_e_12h_dias_uteis",
-        "Quilometragem entre  03h e 12h — Dias Úteis": "quilometragem_entre_03h_e_12h_dias_uteis",
-        "Partidas entre  12h e 21h — Dias Úteis": "partidas_entre_12h_e_21h_dias_uteis",
-        "Quilometragem entre  12h e 21h — Dias Úteis": "quilometragem_entre_12h_e_21h_dias_uteis",
-        "Partidas entre  21h e 24h — Dias Úteis": "partidas_entre_21h_e_24h_dias_uteis",
-        "Quilometragem entre  21h e 24h — Dias Úteis": "quilometragem_entre_21h_e_24h_dias_uteis",
-        "Partidas entre  24h e 03h (dia seguinte) — Dias Úteis": "partidas_entre_24h_e_03h_diaseguinte_dias_uteis",  # noqa
-        "Quilometragem entre  24h e 03h (dia seguinte) — Dias Úteis": "quilometragem_entre_24h_e_03h_diaseguinte_dias_uteis",  # noqa
-        "Partidas entre  03h e 12h — Sábado": "partidas_entre_03h_e_12h_sabado",
-        "Quilometragem entre  03h e 12h — Sábado": "quilometragem_entre_03h_e_12h_sabado",
-        "Partidas entre  12h e 21h — Sábado": "partidas_entre_12h_e_21h_sabado",
-        "Quilometragem entre  12h e 21h — Sábado": "quilometragem_entre_12h_e_21h_sabado",
-        "Partidas entre  21h e 24h — Sábado": "partidas_entre_21h_e_24h_sabado",
-        "Quilometragem entre  21h e 24h — Sábado": "quilometragem_entre_21h_e_24h_sabado",
-        "Partidas entre  24h e 03h (dia seguinte) — Sábado": "partidas_entre_24h_e_03h_diaseguinte_sabado",  # noqa
-        "Quilometragem entre  24h e 03h (dia seguinte) — Sábado": "quilometragem_entre_24h_e_03h_diaseguinte_sabado",  # noqa
-        "Partidas entre  03h e 12h — Domingo": "partidas_entre_03h_e_12h_domingo",
-        "Quilometragem entre  03h e 12h — Domingo": "quilometragem_entre_03h_e_12h_domingo",
-        "Partidas entre  12h e 21h — Domingo": "partidas_entre_12h_e_21h_domingo",
-        "Quilometragem entre  12h e 21h — Domingo": "quilometragem_entre_12h_e_21h_domingo",
-        "Partidas entre  21h e 24h — Domingo": "partidas_entre_21h_e_24h_domingo",
-        "Quilometragem entre  21h e 24h — Domingo": "quilometragem_entre_21h_e_24h_domingo",
-        "Partidas entre  24h e 03h (dia seguinte) — Domingo": "partidas_entre_24h_e_03h_diaseguinte_domingo",  # noqa
-        "Quilometragem entre  24h e 03h (dia seguinte) — Domingo": "quilometragem_entre_24h_e_03h_diaseguinte_domingo",  # noqa
-        "Partidas entre  03h e 12h — Ponto Facultativo": "partidas_entre_03h_e_12h_ponto_facultativo",  # noqa
-        "Quilometragem entre  03h e 12h — Ponto Facultativo": "quilometragem_entre_03h_e_12h_ponto_facultativo",  # noqa
-        "Partidas entre  12h e 21h — Ponto Facultativo": "partidas_entre_12h_e_21h_ponto_facultativo",  # noqa
-        "Quilometragem entre  12h e 21h — Ponto Facultativo": "quilometragem_entre_12h_e_21h_ponto_facultativo",  # noqa
-        "Partidas entre  21h e 24h — Ponto Facultativo": "partidas_entre_21h_e_24h_ponto_facultativo",  # noqa
-        "Quilometragem entre  21h e 24h — Ponto Facultativo": "quilometragem_entre_21h_e_24h_ponto_facultativo",  # noqa
-        "Partidas entre  24h e 03h (dia seguinte) — Ponto Facultativo": "partidas_entre_24h_e_03h_diaseguinte_ponto_facultativo",  # noqa
-        "Quilometragem entre  24h e 03h (dia seguinte) — Ponto Facultativo": "quilometragem_entre_24h_e_03h_diaseguinte_ponto_facultativo",  # noqa
+        "Partidas entre 00h e 03h — Dias Úteis": "partidas_entre_00h_e_03h_dias_uteis",
+        "Quilometragem entre 00h e 03h — Dias Úteis": "quilometragem_entre_00h_e_03h_dias_uteis",
+        "Partidas entre 03h e 12h — Dias Úteis": "partidas_entre_03h_e_12h_dias_uteis",
+        "Quilometragem entre 03h e 12h — Dias Úteis": "quilometragem_entre_03h_e_12h_dias_uteis",
+        "Partidas entre 12h e 21h — Dias Úteis": "partidas_entre_12h_e_21h_dias_uteis",
+        "Quilometragem entre 12h e 21h — Dias Úteis": "quilometragem_entre_12h_e_21h_dias_uteis",
+        "Partidas entre 21h e 24h — Dias Úteis": "partidas_entre_21h_e_24h_dias_uteis",
+        "Quilometragem entre 21h e 24h — Dias Úteis": "quilometragem_entre_21h_e_24h_dias_uteis",
+        "Partidas entre 24h e 03h (dia seguinte) — Dias Úteis": "partidas_entre_24h_e_03h_diaseguinte_dias_uteis",  # noqa
+        "Quilometragem entre 24h e 03h (dia seguinte) — Dias Úteis": "quilometragem_entre_24h_e_03h_diaseguinte_dias_uteis",  # noqa
+        "Partidas entre 03h e 12h — Sábado": "partidas_entre_03h_e_12h_sabado",
+        "Quilometragem entre 03h e 12h — Sábado": "quilometragem_entre_03h_e_12h_sabado",
+        "Partidas entre 12h e 21h — Sábado": "partidas_entre_12h_e_21h_sabado",
+        "Quilometragem entre 12h e 21h — Sábado": "quilometragem_entre_12h_e_21h_sabado",
+        "Partidas entre 21h e 24h — Sábado": "partidas_entre_21h_e_24h_sabado",
+        "Quilometragem entre 21h e 24h — Sábado": "quilometragem_entre_21h_e_24h_sabado",
+        "Partidas entre 24h e 03h (dia seguinte) — Sábado": "partidas_entre_24h_e_03h_diaseguinte_sabado",  # noqa
+        "Quilometragem entre 24h e 03h (dia seguinte) — Sábado": "quilometragem_entre_24h_e_03h_diaseguinte_sabado",  # noqa
+        "Partidas entre 03h e 12h — Domingo": "partidas_entre_03h_e_12h_domingo",
+        "Quilometragem entre 03h e 12h — Domingo": "quilometragem_entre_03h_e_12h_domingo",
+        "Partidas entre 12h e 21h — Domingo": "partidas_entre_12h_e_21h_domingo",
+        "Quilometragem entre 12h e 21h — Domingo": "quilometragem_entre_12h_e_21h_domingo",
+        "Partidas entre 21h e 24h — Domingo": "partidas_entre_21h_e_24h_domingo",
+        "Quilometragem entre 21h e 24h — Domingo": "quilometragem_entre_21h_e_24h_domingo",
+        "Partidas entre 24h e 03h (dia seguinte) — Domingo": "partidas_entre_24h_e_03h_diaseguinte_domingo",  # noqa
+        "Quilometragem entre 24h e 03h (dia seguinte) — Domingo": "quilometragem_entre_24h_e_03h_diaseguinte_domingo",  # noqa
+        "Partidas entre 03h e 12h — Ponto Facultativo": "partidas_entre_03h_e_12h_ponto_facultativo",  # noqa
+        "Quilometragem entre 03h e 12h — Ponto Facultativo": "quilometragem_entre_03h_e_12h_ponto_facultativo",  # noqa
+        "Partidas entre 12h e 21h — Ponto Facultativo": "partidas_entre_12h_e_21h_ponto_facultativo",  # noqa
+        "Quilometragem entre 12h e 21h — Ponto Facultativo": "quilometragem_entre_12h_e_21h_ponto_facultativo",  # noqa
+        "Partidas entre 21h e 24h — Ponto Facultativo": "partidas_entre_21h_e_24h_ponto_facultativo",  # noqa
+        "Quilometragem entre 21h e 24h — Ponto Facultativo": "quilometragem_entre_21h_e_24h_ponto_facultativo",  # noqa
+        "Partidas entre 24h e 03h (dia seguinte) — Ponto Facultativo": "partidas_entre_24h_e_03h_diaseguinte_ponto_facultativo",  # noqa
+        "Quilometragem entre 24h e 03h (dia seguinte) — Ponto Facultativo": "quilometragem_entre_24h_e_03h_diaseguinte_ponto_facultativo",  # noqa
         "tipo_os": "tipo_os",
     }
 
-    ordem_servico_faixa_horaria.columns = ordem_servico_faixa_horaria.columns.str.replace("\n", "")
+    ordem_servico_faixa_horaria.columns = ordem_servico_faixa_horaria.columns.str.replace("\n", " ")
     ordem_servico_faixa_horaria = ordem_servico_faixa_horaria.rename(columns=fh_columns)
-
-    if "tipo_os" not in ordem_servico_faixa_horaria.columns:
-        ordem_servico_faixa_horaria["tipo_os"] = "Regular"
 
     columns_in_dataframe = set(ordem_servico_faixa_horaria.columns)
     columns_in_values = set(list(fh_columns.values()))

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/utils.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/utils.py
@@ -547,8 +547,6 @@ def processa_ordem_servico_faixa_horaria(sheetnames, file_bytes, local_filepath,
         if "ponto_facultativo" in coluna:
             ordem_servico_faixa_horaria[coluna] = 0
 
-    log(f"colunas anexo: {ordem_servico_faixa_horaria.columns}")
-
     columns_in_dataframe = set(ordem_servico_faixa_horaria.columns)
     missing_columns = columns_in_values - columns_in_dataframe
     all_columns_present = columns_in_dataframe.issubset(columns_in_values)

--- a/pipelines/migration/utils.py
+++ b/pipelines/migration/utils.py
@@ -716,14 +716,6 @@ def get_upload_storage_blob(
 
     log(f"blob_list: {blob_list}")
 
-    log(
-        f"""list: {list(
-        bucket.client["storage_staging"]
-        .bucket(bucket.bucket_name)
-        .list_blobs(prefix=f"upload/{dataset_id}")
-    )}"""
-    )
-
     return blob_list[0]
 
 


### PR DESCRIPTION
# Changelog - migration

## [1.0.2] - 2024-09-11

### Adicionado

- Adicionado log à função `get_upload_storage_blob`

# Changelog - gtfs

## [1.1.0] - 2024-09-11

### Alterado

- Criada feature para subida manual com base nos arquivos no GCS
- Função `get_raw_drive_files` transformada em `get_raw_gtfs_files` e adaptada para capturar os arquivos tanto através do Google Drive quanto através do GCS por meio do novo parâmetro `upload_from_gcs` do flow `gtfs_captura_nova` 
- Funções `processa_ordem_servico`, `processa_ordem_servico_trajeto_alternativo` e `processa_ordem_servico_faixa_horaria` ajustadas para considerar a coluna `tipo_os`
- Incorporadas outros nomes de colunas a serem renomeados na função `processa_ordem_servico_faixa_horaria`, bem como corrigido o tratamento de colunas ausentes