### PR TITLE
Ajusta GTFS para Domingo CNU

### DIFF
--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Inserido ajuste para no tipo_os `CNU` com feed_start_date `2024-08-16` considerar o planejamento de sábado do GTFS no domingo no modelo `ordem_servico_trips_shapes_gtfs.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/224)
+- Inserido ajuste para o tipo_os `CNU` com feed_start_date `2024-08-16` considerar o planejamento do GTFS de sábado no domingo. Afetado o modelo `ordem_servico_trips_shapes_gtfs.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/224)
 - Ajustado tratamento dos modelos `ordem_servico_sentido_atualizado_aux_gtfs.sql` e `ordem_servico_trips_shapes_gtfs.sql` em razão da apuração por faixa horária `DATA_SUBSIDIO_V9_INICIO` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/224)
 
 ## [1.1.0] - 2024-09-11

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog - gtfs
 
+## [1.1.1] - 2024-09-13
+
+### Alterado
+
+- Inserido ajuste para no tipo_os `CNU` com feed_start_date `2024-08-16` considerar o planejamento de sábado do GTFS no domingo (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/224)
+- Ajustado tratamento dos modelos `ordem_servico_sentido_atualizado_aux_gtfs.sql` e `ordem_servico_trips_shapes_gtfs.sql` em razão da apuração por faixa horária `DATA_SUBSIDIO_V9_INICIO` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/224)
+
 ## [1.1.0] - 2024-09-11
 
 ### Alterado

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Inserido ajuste para no tipo_os `CNU` com feed_start_date `2024-08-16` considerar o planejamento de sábado do GTFS no domingo (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/224)
+- Inserido ajuste para no tipo_os `CNU` com feed_start_date `2024-08-16` considerar o planejamento de sábado do GTFS no domingo no modelo `ordem_servico_trips_shapes_gtfs.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/224)
 - Ajustado tratamento dos modelos `ordem_servico_sentido_atualizado_aux_gtfs.sql` e `ordem_servico_trips_shapes_gtfs.sql` em razão da apuração por faixa horária `DATA_SUBSIDIO_V9_INICIO` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/224)
 
 ## [1.1.0] - 2024-09-11

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/flows.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/flows.py
@@ -2,7 +2,7 @@
 """
 Flows for gtfs
 
-DBT: 2024-09-10
+DBT: 2024-09-13
 """
 
 from prefect import Parameter, case, task

--- a/queries/models/gtfs/ordem_servico_sentido_atualizado_aux_gtfs.sql
+++ b/queries/models/gtfs/ordem_servico_sentido_atualizado_aux_gtfs.sql
@@ -78,14 +78,13 @@ LEFT JOIN
 USING
     (feed_version, servico)
 WHERE
-    distancia_planejada != 0
-    AND
       (
         (
           feed_start_date < '{{ var("DATA_SUBSIDIO_V9_INICIO") }}'
           AND
             (
-              distancia_total_planejada != 0
+              distancia_planejada != 0
+              AND distancia_total_planejada != 0
               AND (partidas != 0 OR partidas IS NULL)
             )
         )

--- a/queries/models/gtfs/ordem_servico_sentido_atualizado_aux_gtfs.sql
+++ b/queries/models/gtfs/ordem_servico_sentido_atualizado_aux_gtfs.sql
@@ -79,5 +79,16 @@ USING
     (feed_version, servico)
 WHERE
     distancia_planejada != 0
-    AND distancia_total_planejada != 0
-    AND (partidas != 0 OR partidas IS NULL)
+    AND
+      (
+        (
+          feed_start_date < '{{ var("DATA_SUBSIDIO_V9_INICIO") }}'
+          AND
+            (
+              distancia_total_planejada != 0
+              AND (partidas != 0 OR partidas IS NULL)
+            )
+        )
+      OR
+        feed_start_date >= '{{ var("DATA_SUBSIDIO_V9_INICIO") }}'
+      )


### PR DESCRIPTION
# Changelog - gtfs

## [1.1.1] - 2024-09-13

### Alterado

- Inserido ajuste para o tipo_os `CNU` com feed_start_date `2024-08-16` considerar o planejamento do GTFS de sábado no domingo. Afetado o modelo `ordem_servico_trips_shapes_gtfs.sql`
- Ajustado tratamento dos modelos `ordem_servico_sentido_atualizado_aux_gtfs.sql` e `ordem_servico_trips_shapes_gtfs.sql` em razão da apuração por faixa horária `DATA_SUBSIDIO_V9_INICIO`