### PR TITLE
Mudança IP ressarcimento_db Jaé

### DIFF
--- a/pipelines/constants.py
+++ b/pipelines/constants.py
@@ -179,7 +179,7 @@ class constants(Enum):  # pylint: disable=c0103
             },
             "ressarcimento_db": {
                 "engine": "postgresql",
-                "host": "10.5.15.127",
+                "host": "10.5.12.50",
             },
             "gratuidade_db": {
                 "engine": "postgresql",

--- a/pipelines/migration/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [1.4.5] - 2024-09-13
 
 ### Alterado
+- Muda IP do banco ressarcimento_db de `10.5.15.127` para `10.5.12.50`
+
+## [1.4.5] - 2024-09-13
+
+### Alterado
 - Cria tolerância para pular a run no State Handler do flow `bilhetagem_tracking_captura` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/222)
 
 ## [1.4.4] - 2024-09-12

--- a/pipelines/migration/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog - br_rj_riodejaneiro_bilhetagem
 
-## [1.4.5] - 2024-09-13
+## [1.4.6] - 2024-09-13
 
 ### Alterado
-- Muda IP do banco ressarcimento_db de `10.5.15.127` para `10.5.12.50`
+- Muda IP do banco ressarcimento_db de `10.5.15.127` para `10.5.12.50` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/228)
 
 ## [1.4.5] - 2024-09-13
 


### PR DESCRIPTION
# Changelog - br_rj_riodejaneiro_bilhetagem

## [1.4.6] - 2024-09-13

### Alterado
- Muda IP do banco ressarcimento_db de `10.5.15.127` para `10.5.12.50`