### PR TITLE
Cria ambiente hmg

### DIFF
--- a/queries/.gitignore
+++ b/queries/.gitignore
@@ -3,3 +3,4 @@ target/
 dbt_packages/
 logs/
 *dev/
+target-base/

--- a/queries/.gitignore
+++ b/queries/.gitignore
@@ -4,3 +4,4 @@ dbt_packages/
 logs/
 *dev/
 target-base/
+package-lock.yml

--- a/queries/dev/profiles-example.yml
+++ b/queries/dev/profiles-example.yml
@@ -4,7 +4,7 @@ queries:
     dev:
       type: bigquery
       method: service-account
-      project: rj-smtr
+      project: rj-smtr-dev
       dataset: dbt
       location: US
       threads: 1
@@ -29,7 +29,7 @@ queries:
     hmg:
       type: bigquery
       method: service-account
-      project: rj-smtr
+      project: rj-smtr-dev
       dataset: dbt
       location: US
       threads: 1

--- a/queries/dev/profiles-example.yml
+++ b/queries/dev/profiles-example.yml
@@ -1,19 +1,76 @@
-default:
+queries:
   target: dev
   outputs:
     dev:
       type: bigquery
       method: service-account
-      project: rj-smtr-dev
+      project: rj-smtr
       dataset: dbt
       location: US
-      threads: 2
+      threads: 1
       keyfile: # caminho/para/sua/credencial.json
+      priority: interactive
+      job_retries: 1
+
+      # for dbt Python models to be run on Dataproc Serverless
+      gcs_bucket: rj-smtr
+      dataproc_region: us-central1
+      submission_method: serverless
+      dataproc_batch:
+        environment_config:
+          execution_config:
+            service_account: # sua-conta-de-servico
+
+        runtime_config:
+          properties:
+            spark.executor.instances: "2"
+            spark.driver.memory: 4g
+            spark.driver.memoryOverhead: 1g
+    hmg:
+      type: bigquery
+      method: service-account
+      project: rj-smtr
+      dataset: dbt
+      location: US
+      threads: 1
+      keyfile: # caminho/para/sua/credencial.json
+      priority: interactive
+      job_retries: 1
+
+      # for dbt Python models to be run on Dataproc Serverless
+      gcs_bucket: rj-smtr
+      dataproc_region: us-central1
+      submission_method: serverless
+      dataproc_batch:
+        environment_config:
+          execution_config:
+            service_account: # sua-conta-de-servico
+
+        runtime_config:
+          properties:
+            spark.executor.instances: "2"
+            spark.driver.memory: 4g
+            spark.driver.memoryOverhead: 1g
     prod:
       type: bigquery
       method: service-account
       project: rj-smtr
       dataset: dbt
       location: US
-      threads: 2
+      threads: 1
       keyfile: # caminho/para/sua/credencial.json
+
+      # for dbt Python models to be run on Dataproc Serverless
+      gcs_bucket: rj-smtr
+      dataproc_region: us-central1
+      submission_method: serverless
+      dataproc_batch:
+        environment_config:
+          execution_config:
+            service_account: # sua-conta-de-servico
+
+        runtime_config:
+          properties:
+            spark.executor.instances: "2"
+            spark.driver.memory: 4g
+            spark.driver.memoryOverhead: 1g

--- a/queries/dev/utils.py
+++ b/queries/dev/utils.py
@@ -63,6 +63,7 @@ def run_dbt_model(
         run_command += f" {flags}"
 
     print(f"\n>>> RUNNING: {run_command}\n")
+    os.chdir(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
     os.system(run_command)
 
 

--- a/queries/macros/generate_database_name.sql
+++ b/queries/macros/generate_database_name.sql
@@ -1,0 +1,24 @@
+-- fmt: off
+{% macro generate_database_name(custom_database_name=none, node=none) -%}
+
+    {%- set default_database = target.database -%}
+    {% set dev_database = "rj-smtr-dev" %}
+    {%- if custom_database_name is none -%}
+
+        {% if target.name in ("dev", "hmg") %}
+
+            {{ dev_database }}
+
+        {% else %}
+
+            {{ default_database }}
+
+        {% endif %}
+
+    {%- else -%}
+
+        {{ custom_database_name | trim }}
+
+    {%- endif -%}
+
+{%- endmacro %}

--- a/queries/macros/generate_schema_name.sql
+++ b/queries/macros/generate_schema_name.sql
@@ -16,5 +16,10 @@
         {% set schema_name = env_var("DBT_USER") + "__" + schema_name %}
     {% endif %}
 
+    {% if target.name in ("dev", "hmg") and schema_name.endswith("_staging") %}
+        {% set schema_name = schema_name + "_dbt" %}
+    {% endif %}
+
     {{ schema_name }}
+
 {%- endmacro %}

--- a/queries/macros/generate_schema_name.sql
+++ b/queries/macros/generate_schema_name.sql
@@ -16,7 +16,7 @@
         {% set schema_name = env_var("DBT_USER") + "__" + schema_name %}
     {% endif %}
 
-    {% if target.name in ("dev", "hmg") and schema_name.endswith("_staging") %}
+    {% if target.name == "hmg" and schema_name.endswith("_staging") %}
         {% set schema_name = schema_name + "_dbt" %}
     {% endif %}
 

--- a/queries/macros/generate_schema_name.sql
+++ b/queries/macros/generate_schema_name.sql
@@ -1,14 +1,20 @@
+-- fmt: off
 {% macro generate_schema_name(custom_schema_name, node) -%}
 
     {%- set default_schema = target.schema -%}
     {%- if custom_schema_name is none -%}
 
-        {{ default_schema }}
+        {% set schema_name = default_schema %}
 
     {%- else -%}
 
-        {{ custom_schema_name | trim }}
+        {% set schema_name = custom_schema_name | trim %}
 
     {%- endif -%}
 
+    {% if target.name == "dev" %}
+        {% set schema_name = env_var("DBT_USER") + "__" + schema_name %}
+    {% endif %}
+
+    {{ schema_name }}
 {%- endmacro %}

--- a/queries/packages.yml
+++ b/queries/packages.yml
@@ -1,0 +1,5 @@
+packages:
+  - package: dbt-labs/audit_helper
+    version: 0.12.0
+  - package: data-mie/dbt_profiler
+    version: 0.8.2

--- a/queries/profiles.yml
+++ b/queries/profiles.yml
@@ -11,6 +11,47 @@ queries:
       project: rj-smtr-dev
       threads: 1
       type: bigquery
+
+      # for dbt Python models to be run on Dataproc Serverless
+      gcs_bucket: rj-smtr
+      dataproc_region: us-central1
+      submission_method: serverless
+      dataproc_batch:
+        environment_config:
+          execution_config:
+            service_account: prefect@rj-smtr-dev.iam.gserviceaccount.com
+
+        runtime_config:
+          properties:
+            spark.executor.instances: "2"
+            spark.driver.memory: 4g
+            spark.driver.memoryOverhead: 1g
+    hmg:
+      dataset: dbt
+      job_execution_timeout_seconds: 600
+      job_retries: 1
+      keyfile: /tmp/credentials.json
+      location: us
+      method: service-account
+      priority: interactive
+      project: rj-smtr-dev
+      threads: 1
+      type: bigquery
+
+      # for dbt Python models to be run on Dataproc Serverless
+      gcs_bucket: rj-smtr
+      dataproc_region: us-central1
+      submission_method: serverless
+      dataproc_batch:
+        environment_config:
+          execution_config:
+            service_account: prefect@rj-smtr-dev.iam.gserviceaccount.com
+
+        runtime_config:
+          properties:
+            spark.executor.instances: "2"
+            spark.driver.memory: 4g
+            spark.driver.memoryOverhead: 1g
     prod:
       dataset: dbt
       job_execution_timeout_seconds: 600
@@ -22,4 +63,19 @@ queries:
       project: rj-smtr
       threads: 1
       type: bigquery
+
+      # for dbt Python models to be run on Dataproc Serverless
+      gcs_bucket: rj-smtr
+      dataproc_region: us-central1
+      submission_method: serverless
+      dataproc_batch:
+        environment_config:
+          execution_config:
+            service_account: prefect@rj-smtr.iam.gserviceaccount.com
+
+        runtime_config:
+          properties:
+            spark.executor.instances: "2"
+            spark.driver.memory: 4g
+            spark.driver.memoryOverhead: 1g
   target: prod

--- a/queries/recce.yml
+++ b/queries/recce.yml
@@ -1,0 +1,13 @@
+# Preset Checks
+# Please see https://datarecce.io/docs/features/preset-checks/
+checks:
+- name: Row count diff
+  description: Check the row count diff for all table models.
+  type: row_count_diff
+  params:
+    select: state:modified,config.materialized:table
+- name: Schema diff
+  description: Check the schema diff for all nodes.
+  type: schema_diff
+  params:
+    select: state:modified


### PR DESCRIPTION
# ChangeLog

## Adicionado
- Cria macro `generate_database_name.sql` para garantir que os ambientes de `dev` e `hmg` escrevam no projeto `rj-smtr-dev` independente da key `project` do profile
- Cria arquivo `packages.yml` para adicionar pacotes necessários para utilizar todas as funcionalidades do `Recce`
- Cria arquivo `recce.yml`

## Alterado
- Adiciona `target-base/` e `package-lock.yml` no `.gitignore`
- Adiciona ambiente de `hmg` e configurações do `DataProc` nos arquivos `profiles-example.yml` e `profiles.yml`
- Altera função `run_dbt_model` para executar o comando sempre da pasta queries
- Diferencia ambiente de `dev` e `hmg` na macro `generate_schema_name.sql`
