### PR TITLE
Altera encoding do controle financeiro para utf-8

### DIFF
--- a/pipelines/migration/controle_financeiro/CHANGELOG.md
+++ b/pipelines/migration/controle_financeiro/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - controle_financeiro
 
+## [1.2.1] - 2024-09-25
+
+### Alterado
+
+- Altera encoding das planilhas de controle financeiro `cb` e `cett` de `Windows-1252` para `UTF-8`
+
 ## [1.2.0] - 2024-06-13
 
 ### Alterado

--- a/pipelines/migration/controle_financeiro/CHANGELOG.md
+++ b/pipelines/migration/controle_financeiro/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Altera encoding das planilhas de controle financeiro `cb` e `cett` de `Windows-1252` para `UTF-8`
+- Altera encoding das planilhas de controle financeiro `cb` e `cett` de `Windows-1252` para `UTF-8` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/248)
 
 ## [1.2.0] - 2024-06-13
 

--- a/pipelines/migration/utils.py
+++ b/pipelines/migration/utils.py
@@ -633,12 +633,7 @@ def save_raw_local_func(
             json.dump(data, fi, default=custom_serialization)
 
     if filetype in ("txt", "csv"):
-        if constants.CONTROLE_FINANCEIRO_DATASET_ID.value in _filepath:
-            encoding = "Windows-1252"
-        else:
-            encoding = "utf-8"
-
-        with open(_filepath, "w", encoding=encoding) as file:
+        with open(_filepath, "w", encoding="utf-8") as file:
             file.write(data)
 
     log(f"Raw data saved to: {_filepath}")


### PR DESCRIPTION
# Changelog - controle_financeiro

## [1.2.1] - 2024-09-25

### Alterado

- Altera encoding das planilhas de controle financeiro `cb` e `cett` de `Windows-1252` para `UTF-8`