### PR TITLE
Corrige duplicação de viagens em viagem_planejada

### DIFF
--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - projeto_subsidio_sppo
 
+## [9.0.4] - 2024-10-08
+
+### Corrigido
+
+- Corrigido a duplicação de viagens no modelo `viagens_planejadas` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/266)
+
 ## [9.0.3] - 2024-09-23
 
 ### Alterado

--- a/queries/models/projeto_subsidio_sppo/viagem_planejada.sql
+++ b/queries/models/projeto_subsidio_sppo/viagem_planejada.sql
@@ -270,6 +270,7 @@ WITH
         sentido,
         trip_id_planejado,
         trip_id,
+        shape_id,
     FROM
       {{ ref("ordem_servico_trips_shapes_gtfs") }}
     --   rj-smtr.gtfs.ordem_servico_trips_shapes
@@ -462,7 +463,7 @@ LEFT JOIN
 USING (feed_start_date, feed_version, tipo_dia, tipo_os)
 LEFT JOIN
   trips AS t
-USING (feed_start_date, feed_version, tipo_dia, tipo_os, servico, sentido)
+USING (feed_start_date, feed_version, tipo_dia, tipo_os, servico, sentido, shape_id)
 WHERE
   data = DATE_SUB("{{ var('run_date') }}", INTERVAL 1 DAY)
   AND faixa_horaria_inicio != "24:00:00"


### PR DESCRIPTION
# Changelog - projeto_subsidio_sppo

## [9.0.4] - 2024-10-08

### Corrigido

- Corrigido a duplicação de viagens no modelo `viagens_planejadas` 