### PR TITLE
cria exceção para eleição de 2024-10-06 viagem_transacao de 06h as 20h

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT: 2024-10-22
+DBT: 2024-10-24
 """
 
 from prefect import Parameter, case, task

--- a/queries/models/subsidio/CHANGELOG.md
+++ b/queries/models/subsidio/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - subsidio
 
+## [1.0.2] - 2024-10-24
+
+- cria exceção na verificação d viagens sem transacao para a eleição de 2024-10-06 em viagem_transacao de 06h as 20h (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/286)
+
 ## [1.0.1] - 2024-09-12
 
 ### Corrigido

--- a/queries/models/subsidio/viagem_transacao.sql
+++ b/queries/models/subsidio/viagem_transacao.sql
@@ -217,6 +217,7 @@ SELECT
       AND (COALESCE(tr.quantidade_transacao_riocard, 0) = 0
         OR COALESCE(eev.indicador_estado_equipamento_aberto, FALSE) = FALSE)
       AND ve.status IN ("Licenciado com ar e não autuado", "Licenciado sem ar e não autuado")
+      AND v.datetime_partida NOT BETWEEN "2024-10-06 06:00:00" AND "2024-10-06 20:00:00" --  Eleição (2024-10-06)
       THEN "Sem transação"
     ELSE ve.status
   END AS tipo_viagem,


### PR DESCRIPTION
# Changelog - subsidio

## [1.0.2] - 2024-10-24

- cria exceção na verificação d viagens sem transacao para a eleição de 2024-10-06 em viagem_transacao de 06h as 20h