### PR TITLE
Corrige dados do dia anterior em caso de mudança de feed e limita janela de dados capturados em `viagem_transacao`

### DIFF
--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Corrigido
 
-- Corrigida a origem da distancia total planejada na faixa horaria de 24 a 27 horas no modelo `viagem_planejada` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/346)
+- Corrigida a origem da coluna `distancia_total_planejada` na faixa hor[aria de 24h às 27h no modelo `viagem_planejada.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/346)
 
 ## [9.0.8] - 2024-11-28
 

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - projeto_subsidio_sppo
 
+## [9.0.9] - 2024-11-29
+
+## Corrigido
+
+- Corrigida a origem da distancia total planejada na faixa horaria de 24 a 27 horas no modelo `viagem_planejada` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/346)
+
 ## [9.0.8] - 2024-11-28
 
 ### Alterado

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [9.0.9] - 2024-11-29
 
-## Corrigido
+### Corrigido
 
 - Corrigida a origem da distancia total planejada na faixa horaria de 24 a 27 horas no modelo `viagem_planejada` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/346)
 

--- a/queries/models/projeto_subsidio_sppo/viagem_planejada.sql
+++ b/queries/models/projeto_subsidio_sppo/viagem_planejada.sql
@@ -267,7 +267,7 @@ WITH
     ts.sentido,
     ts.partidas_total_planejada,
     da.distancia_planejada,
-    da.distancia_total_planejada,
+    ts.distancia_total_planejada,
     da.inicio_periodo,
     da.fim_periodo,
     "00:00:00" AS faixa_horaria_inicio,

--- a/queries/models/subsidio/CHANGELOG.md
+++ b/queries/models/subsidio/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 # Alterado
 
-- Alterada a janela de dados considerados no modelo `viagem_transacao` para 6 dias (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/346)
+- Alterada a janela de dados considerados no modelo `viagem_transacao.sql` para 6 dias (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/346)
 
 ## [1.0.2] - 2024-10-24
 

--- a/queries/models/subsidio/CHANGELOG.md
+++ b/queries/models/subsidio/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Adicionado
 
-- Adicionada exceção na verificação d viagens sem transacao para a eleição de 2024-10-06 em viagem_transacao de 06h as 20h (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/286)
+- Adicionada exceção na verificação de viagens sem transação para a eleição de 2024-10-06 no modelo `viagem_transacao.sql` de 06h às 20h (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/286)
 
 ## [1.0.1] - 2024-09-12
 

--- a/queries/models/subsidio/CHANGELOG.md
+++ b/queries/models/subsidio/CHANGELOG.md
@@ -1,17 +1,25 @@
 # Changelog - subsidio
 
+## [1.0.3] - 2024-11-29
+
+# Alterado
+
+- Alterada a janela de dados considerados no modelo `viagem_transacao` para 6 dias (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/346)
+
 ## [1.0.2] - 2024-10-24
 
-- cria exceção na verificação d viagens sem transacao para a eleição de 2024-10-06 em viagem_transacao de 06h as 20h (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/286)
+### Adicionado
+
+- Adicionada exceção na verificação d viagens sem transacao para a eleição de 2024-10-06 em viagem_transacao de 06h as 20h (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/286)
 
 ## [1.0.1] - 2024-09-12
 
 ### Corrigido
 
-- Corriido o tratamento de `viagem_transacao` para lidar com casos de mudança aberto/fechado ao longo da viagem, lat, long zerada do validador, mais de um validador associado ao veículo e viagem que inicia/encerra em dia diferente(https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/210)
+- Corrigido o tratamento de `viagem_transacao` para lidar com casos de mudança aberto/fechado ao longo da viagem, lat, long zerada do validador, mais de um validador associado ao veículo e viagem que inicia/encerra em dia diferente(https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/210)
 
 ## [1.0.0] - 2024-07-31
 
 ### Adicionado
 
-- Cria modelo `viagem_transacao.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/121)
+- Adicionado modelo `viagem_transacao.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/121)

--- a/queries/models/subsidio/CHANGELOG.md
+++ b/queries/models/subsidio/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Corrigido
 
-- Corrigido o tratamento de `viagem_transacao` para lidar com casos de mudança aberto/fechado ao longo da viagem, lat, long zerada do validador, mais de um validador associado ao veículo e viagem que inicia/encerra em dia diferente(https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/210)
+- Corrigido o tratamento do modelo `viagem_transacao.sql` para lidar com casos de mudança aberto/fechado ao longo da viagem, lat, long zerada do validador, mais de um validador associado ao veículo e viagem que inicia/encerra em dia diferente (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/210)
 
 ## [1.0.0] - 2024-07-31
 

--- a/queries/models/subsidio/viagem_transacao.sql
+++ b/queries/models/subsidio/viagem_transacao.sql
@@ -18,6 +18,7 @@ WITH
     WHERE
     data BETWEEN DATE("{{ var("start_date") }}")
     AND DATE_ADD(DATE("{{ var("end_date") }}"), INTERVAL 1 DAY)
+    AND DATE(datetime_processamento) <= DATE_ADD(DATE("{{ var("end_date") }}"), INTERVAL 6 DAY)
   ),
   -- 2. Transações RioCard
   transacao_riocard AS (
@@ -30,6 +31,7 @@ WITH
     WHERE
       data BETWEEN DATE("{{ var("start_date") }}")
       AND DATE_ADD(DATE("{{ var("end_date") }}"), INTERVAL 1 DAY)
+      AND DATE(datetime_processamento) <= DATE_ADD(DATE("{{ var("end_date") }}"), INTERVAL 6 DAY)
   ),
   -- 3. GPS Validador
   gps_validador AS (
@@ -48,6 +50,7 @@ WITH
       data BETWEEN DATE("{{ var("start_date") }}")
       AND DATE_ADD(DATE("{{ var("end_date") }}"), INTERVAL 1 DAY)
       AND (latitude != 0 OR longitude != 0)
+      AND DATE(datetime_captura) <= DATE_ADD(DATE("{{ var("end_date") }}"), INTERVAL 6 DAY)
   ),
   -- 4. Viagens realizadas
   viagem AS (


### PR DESCRIPTION
# Changelog - projeto_subsidio_sppo

## [9.0.9] - 2024-11-29

## Corrigido

- Corrigida a origem da distancia total planejada na faixa horaria de 24 a 27 horas no modelo `viagem_planejada` 

# Changelog - subsidio

## [1.0.3] - 2024-11-29

# Alterado

- Alterada a janela de dados considerados no modelo `viagem_transacao` para 6 dias