### PR TITLE
Correção para o tipo_os `Enem`

### DIFF
--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/flows.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/flows.py
@@ -2,7 +2,7 @@
 """
 Flows for gtfs
 
-DBT 2024-11-07
+DBT 2024-12-04
 """
 
 from prefect import Parameter, case, task

--- a/queries/models/gtfs/CHANGELOG.md
+++ b/queries/models/gtfs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - gtfs
 
+## [1.2.0] - 2024-12-04
+
+### Alterado
+
+- Inserido ajuste para o tipo_os `Enem` com feed_start_date `2024-09-29` e `2024-11-06` para considerar o planejamento do GTFS de sábado no domingo. Afetado o modelo `ordem_servico_trips_shapes_gtfs.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+
 ## [1.1.9] - 2024-09-10
 
 ### Alterado

--- a/queries/models/gtfs/CHANGELOG.md
+++ b/queries/models/gtfs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Inserido ajuste para o tipo_os `Enem` com feed_start_date `2024-09-29` e `2024-11-06` para considerar o planejamento do GTFS de sábado no domingo. Afetado o modelo `ordem_servico_trips_shapes_gtfs.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+- Inserido ajuste para o tipo_os `Enem` com feed_start_date `2024-09-29` e `2024-11-06` para considerar o planejamento do GTFS de sábado no domingo. Afetado o modelo `ordem_servico_trips_shapes_gtfs.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/354)
 
 ## [1.1.9] - 2024-09-10
 

--- a/queries/models/gtfs/ordem_servico_trips_shapes_gtfs.sql
+++ b/queries/models/gtfs/ordem_servico_trips_shapes_gtfs.sql
@@ -53,9 +53,10 @@ WITH
         t.feed_version = o.feed_version
         AND o.servico = t.trip_short_name
         AND
-          ((o.tipo_dia = t.tipo_dia AND o.tipo_os != "CNU")
+          ((o.tipo_dia = t.tipo_dia AND o.tipo_os NOT IN ("CNU", "Enem"))
           OR (o.tipo_dia = "Ponto Facultativo" AND t.tipo_dia = "Dia Útil" AND o.tipo_os != "CNU")
           OR (o.feed_start_date = "2024-08-16" AND o.tipo_os = "CNU" AND o.tipo_dia = "Domingo" AND t.tipo_dia = "Sabado")) -- Domingo CNU
+          OR (o.feed_start_date IN ("2024-09-29", "2024-11-06") AND o.tipo_os = "Enem" AND o.tipo_dia = "Domingo" AND t.tipo_dia = "Sabado")) -- Domingo Enem
         AND
           ((o.sentido IN ("I", "C") AND t.direction_id = "0")
           OR (o.sentido = "V" AND t.direction_id = "1"))


### PR DESCRIPTION
# Changelog - gtfs

## [1.2.0] - 2024-12-04

### Alterado

- Inserido ajuste para o tipo_os `Enem` com feed_start_date `2024-09-29` e `2024-11-06` para considerar o planejamento do GTFS de sábado no domingo. Afetado o modelo `ordem_servico_trips_shapes_gtfs.sql`