### PR TITLE
Corrige e refatora modelo `viagem_transacao.sql`

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT: 2024-12-02
+DBT: 2024-12-11
 """
 
 from prefect import Parameter, case, task

--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -128,6 +128,8 @@ vars:
   # valor_subsidio: "`rj-smtr-dev.projeto_subsidio_sppo.valor_subsidio`"
   DATA_SUBSIDIO_V11_INICIO: "2024-11-06"
 
+  DATA_SUBSIDIO_V12_INICIO: "2024-11-16"
+
   # Recursos #
   recurso_staging: "rj-smtr-staging.projeto_subsidio_sppo_staging.recurso"
   recurso_prazo: "rj-smtr.projeto_subsidio_sppo.recurso_prazo"

--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -128,6 +128,7 @@ vars:
   # valor_subsidio: "`rj-smtr-dev.projeto_subsidio_sppo.valor_subsidio`"
   DATA_SUBSIDIO_V11_INICIO: "2024-11-06"
 
+  # Alterações de regras do modelo `viagem_transacao.sql`
   DATA_SUBSIDIO_V12_INICIO: "2024-11-16"
 
   # Recursos #

--- a/queries/models/subsidio/CHANGELOG.md
+++ b/queries/models/subsidio/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 # Corrigido
 
-- Corrigido e refatorado o modelo `viagem_transacao.sql`:
+- Corrigido e refatorado o modelo `viagem_transacao.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/357):
     - Reformatação conforme padrão `sqlfmt`
     - Passa a considerar registros de GPS do validador com coordenadas zeradas a partir de `DATA_SUBSIDIO_V12_INICIO`
     - Alterada janela de dados da CTE `viagem`, de forma a não ocorrer sobreposição entre viagens finalizadas na partição do dia anterior ao `start_date`

--- a/queries/models/subsidio/CHANGELOG.md
+++ b/queries/models/subsidio/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog - subsidio
 
+## [2.0.0] - 2024-12-06
+
+# Corrigido
+
+- Corrigido e refatorado o modelo `viagem_transacao.sql`:
+    - Reformatação conforme padrão `sqlfmt`
+    - Passa a considerar registros de GPS do validador com coordenadas zeradas a partir de `DATA_SUBSIDIO_V12_INICIO`
+    - Alterada janela de dados da CTE `viagem`, de forma a não ocorrer sobreposição entre viagens finalizadas na partição do dia anterior ao `start_date`
+    - Passa a considerar uma transação RioCard ou Jaé para fins de validação do SBD a partir de `DATA_SUBSIDIO_V12_INICIO`
+
 ## [1.0.3] - 2024-11-29
 
 # Alterado

--- a/queries/models/subsidio/viagem_transacao.sql
+++ b/queries/models/subsidio/viagem_transacao.sql
@@ -6,248 +6,304 @@
     )
 }}
 
-WITH
-  -- 1. Transações Jaé
-  transacao AS (
-    SELECT
-      id_veiculo,
-      datetime_transacao
-    FROM
-      {{ ref("transacao") }}
-      -- rj-smtr.br_rj_riodejaneiro_bilhetagem.transacao
-    WHERE
-    data BETWEEN DATE("{{ var("start_date") }}")
-    AND DATE_ADD(DATE("{{ var("end_date") }}"), INTERVAL 1 DAY)
-    AND DATE(datetime_processamento) <= DATE_ADD(DATE("{{ var("end_date") }}"), INTERVAL 6 DAY)
-  ),
-  -- 2. Transações RioCard
-  transacao_riocard AS (
-    SELECT
-      id_veiculo,
-      datetime_transacao
-    FROM
-      {{ ref("transacao_riocard") }}
-      -- rj-smtr.br_rj_riodejaneiro_bilhetagem.transacao_riocard
-    WHERE
-      data BETWEEN DATE("{{ var("start_date") }}")
-      AND DATE_ADD(DATE("{{ var("end_date") }}"), INTERVAL 1 DAY)
-      AND DATE(datetime_processamento) <= DATE_ADD(DATE("{{ var("end_date") }}"), INTERVAL 6 DAY)
-  ),
-  -- 3. GPS Validador
-  gps_validador AS (
-    SELECT
-      data,
-      datetime_gps,
-      id_veiculo,
-      id_validador,
-      estado_equipamento,
-      latitude,
-      longitude
-    FROM
-      {{ ref("gps_validador") }}
-      -- rj-smtr.br_rj_riodejaneiro_bilhetagem.gps_validador
-    WHERE
-      data BETWEEN DATE("{{ var("start_date") }}")
-      AND DATE_ADD(DATE("{{ var("end_date") }}"), INTERVAL 1 DAY)
-      AND (latitude != 0 OR longitude != 0)
-      AND DATE(datetime_captura) <= DATE_ADD(DATE("{{ var("end_date") }}"), INTERVAL 6 DAY)
-  ),
-  -- 4. Viagens realizadas
-  viagem AS (
-  SELECT
-    data,
-    servico_realizado AS servico,
-    datetime_partida,
-    datetime_chegada,
-    id_veiculo,
-    id_viagem,
-    distancia_planejada
- FROM
-    {{ ref("viagem_completa") }}
-    -- rj-smtr.projeto_subsidio_sppo.viagem_completa
-  WHERE
-    data BETWEEN DATE("{{ var("start_date") }}")
-    AND DATE( "{{ var("end_date") }}" ) ),
-  -- 5. Status dos veículos
-  veiculos AS (
-  SELECT
-    data,
-    id_veiculo,
-    status
-  FROM
-    {{ ref("sppo_veiculo_dia") }}
-    -- rj-smtr.veiculo.sppo_veiculo_dia
-  WHERE
-    data BETWEEN DATE("{{ var("start_date") }}")
-    AND DATE("{{ var("end_date") }}") ),
-  -- 6. Viagem, para fins de contagem de passageiros, com tolerância de 30 minutos, limitada pela viagem anterior
-  viagem_com_tolerancia AS (
-    SELECT
-      v.*,
-      LAG(v.datetime_chegada) OVER (PARTITION BY v.id_veiculo ORDER BY v.datetime_partida) AS viagem_anterior_chegada,
-      CASE
-        WHEN LAG(v.datetime_chegada) OVER (PARTITION BY v.id_veiculo ORDER BY v.datetime_partida) IS NULL THEN
-          DATETIME(TIMESTAMP_SUB(datetime_partida, INTERVAL 30 MINUTE))
-        ELSE
-          DATETIME(TIMESTAMP_ADD(GREATEST(
-            TIMESTAMP_SUB(datetime_partida, INTERVAL 30 MINUTE),
-            LAG(v.datetime_chegada) OVER (PARTITION BY v.id_veiculo ORDER BY v.datetime_partida)
-          ), INTERVAL 1 SECOND))
-      END AS datetime_partida_com_tolerancia
-    FROM
-      viagem AS v
-  ),
-  -- 7. Contagem de transações Jaé
-  transacao_contagem AS (
-    SELECT
-      v.data,
-      v.id_viagem,
-      COUNT(t.datetime_transacao) AS quantidade_transacao
-    FROM
-      transacao AS t
-    JOIN
-      viagem_com_tolerancia AS v
-    ON
-      t.id_veiculo = SUBSTR(v.id_veiculo, 2)
-      AND t.datetime_transacao BETWEEN v.datetime_partida_com_tolerancia AND v.datetime_chegada
-    GROUP BY
-      v.data, v.id_viagem
-  ),
-  -- 5. Contagem de transações RioCard
-  transacao_riocard_contagem AS (
-    SELECT
-      v.data,
-      v.id_viagem,
-      COUNT(tr.datetime_transacao) AS quantidade_transacao_riocard
-    FROM
-      transacao_riocard AS tr
-    JOIN
-      viagem_com_tolerancia AS v
-    ON
-      tr.id_veiculo = SUBSTR(v.id_veiculo, 2)
-      AND tr.datetime_transacao BETWEEN v.datetime_partida_com_tolerancia AND v.datetime_chegada
-    GROUP BY
-      v.data, v.id_viagem
-  ),
-  -- 6. Ajusta estado do equipamento
-  -- Agrupa mesma posição para mesmo validador e veículo, mantendo preferencialmente o estado do equipamento "ABERTO"
-  estado_equipamento_aux AS (
-    SELECT
-      data,
-      id_validador,
-      id_veiculo,
-      latitude,
-      longitude,
-      IF(COUNT(CASE WHEN estado_equipamento = "ABERTO" THEN 1 END) >= 1, "ABERTO", "FECHADO") AS estado_equipamento,
-      MIN(datetime_gps) AS datetime_gps,
-    FROM
-      gps_validador
-    GROUP BY
-      1,
-      2,
-      3,
-      4,
-      5
-  ),
-  -- 7. Relacionamento entre estado do equipamento e viagem
-  gps_validador_viagem AS (
-    SELECT
-      v.data,
-      e.datetime_gps,
-      v.id_viagem,
-      e.id_validador,
-      e.estado_equipamento,
-      e.latitude,
-      e.longitude
-    FROM
-      estado_equipamento_aux AS e
-    JOIN
-      viagem AS v
-    ON
-      e.id_veiculo = SUBSTR(v.id_veiculo, 2)
-      AND e.datetime_gps BETWEEN v.datetime_partida AND v.datetime_chegada
-  ),
-  -- 8. Calcula a porcentagem de estado do equipamento "ABERTO" por validador e viagem
-  estado_equipamento_perc AS (
-    SELECT
-      data,
-      id_viagem,
-      id_validador,
-      COUNTIF(estado_equipamento = "ABERTO") / COUNT(*) AS percentual_estado_equipamento_aberto
-    FROM
-      gps_validador_viagem
-    GROUP BY
-      1,
-      2,
-      3
-  ),
-  -- 9. Considera o validador com maior porcentagem de estado do equipamento "ABERTO" por viagem
-  estado_equipamento_max_perc AS (
-    SELECT
-      data,
-      id_viagem,
-      MAX_BY(id_validador, percentual_estado_equipamento_aberto) AS id_validador,
-      MAX(percentual_estado_equipamento_aberto) AS percentual_estado_equipamento_aberto
-    FROM
-      estado_equipamento_perc
-    GROUP BY
-      1,
-      2
-  ),
-  -- 10. Verifica se a viagem possui estado do equipamento "ABERTO" em pelo menos 80% dos registros
-  estado_equipamento_verificacao AS (
-    SELECT
-      data,
-      id_viagem,
-      id_validador,
-      percentual_estado_equipamento_aberto,
-      IF(percentual_estado_equipamento_aberto >= 0.8 OR percentual_estado_equipamento_aberto IS NULL, TRUE, FALSE) AS indicador_estado_equipamento_aberto
-    FROM
-      viagem
-    LEFT JOIN
-      estado_equipamento_max_perc
-    USING
-      (data, id_viagem)
-  )
-SELECT
-  v.data,
-  v.id_viagem,
-  v.id_veiculo,
-  v.servico,
-  eev.id_validador,
-  CASE
-    WHEN v.data >= DATE("{{ var("DATA_SUBSIDIO_V8_INICIO") }}")
-      AND (COALESCE(tr.quantidade_transacao_riocard, 0) = 0
-        OR COALESCE(eev.indicador_estado_equipamento_aberto, FALSE) = FALSE)
-      AND ve.status IN ("Licenciado com ar e não autuado", "Licenciado sem ar e não autuado")
-      AND v.datetime_partida NOT BETWEEN "2024-10-06 06:00:00" AND "2024-10-06 20:00:00" --  Eleição (2024-10-06)
-      THEN "Sem transação"
-    ELSE ve.status
-  END AS tipo_viagem,
-  v.distancia_planejada,
-  COALESCE(t.quantidade_transacao, 0) AS quantidade_transacao,
-  COALESCE(tr.quantidade_transacao_riocard, 0) AS quantidade_transacao_riocard,
-  eev.percentual_estado_equipamento_aberto,
-  eev.indicador_estado_equipamento_aberto,
-  v.datetime_partida_com_tolerancia AS datetime_partida_bilhetagem,
-  v.datetime_partida,
-  v.datetime_chegada,
-  CURRENT_DATETIME("America/Sao_Paulo") AS datetime_ultima_atualizacao
-FROM
-  viagem_com_tolerancia AS v
-LEFT JOIN
-  veiculos AS ve
-USING
-  (data, id_veiculo)
-LEFT JOIN
-  transacao_contagem AS t
-USING
-  (data, id_viagem)
-LEFT JOIN
-  transacao_riocard_contagem AS tr
-USING
-  (data, id_viagem)
-LEFT JOIN
-  estado_equipamento_verificacao AS eev
-USING
-  (data, id_viagem)
+with
+    -- 1. Transações Jaé
+    transacao as (
+        select id_veiculo, datetime_transacao
+        from {{ ref("transacao") }}
+        -- rj-smtr.br_rj_riodejaneiro_bilhetagem.transacao
+        where
+            data between date("{{ var('start_date') }}") and date_add(
+                date("{{ var('end_date') }}"), interval 1 day
+            )
+            and date(datetime_processamento)
+            <= date_add(date("{{ var('end_date') }}"), interval 6 day)
+    ),
+    -- 2. Transações RioCard
+    transacao_riocard as (
+        select id_veiculo, datetime_transacao
+        from {{ ref("transacao_riocard") }}
+        -- rj-smtr.br_rj_riodejaneiro_bilhetagem.transacao_riocard
+        where
+            data between date("{{ var('start_date') }}") and date_add(
+                date("{{ var('end_date') }}"), interval 1 day
+            )
+            and date(datetime_processamento)
+            <= date_add(date("{{ var('end_date') }}"), interval 6 day)
+    ),
+    -- 3. GPS Validador
+    gps_validador as (
+        select
+            data,
+            datetime_gps,
+            id_veiculo,
+            id_validador,
+            estado_equipamento,
+            latitude,
+            longitude
+        from {{ ref("gps_validador") }}
+        -- rj-smtr.br_rj_riodejaneiro_bilhetagem.gps_validador
+        where
+            data between date("{{ var('start_date') }}") and date_add(
+                date("{{ var('end_date') }}"), interval 1 day
+            )
+            and (
+                (
+                    data < date("{{ var('DATA_SUBSIDIO_V12_INICIO') }}")
+                    and (latitude != 0 or longitude != 0)
+                )
+                or data >= date("{{ var('DATA_SUBSIDIO_V12_INICIO') }}")
+            )
+            and date(datetime_captura)
+            <= date_add(date("{{ var('end_date') }}"), interval 6 day)
+    ),
+    -- 4. Viagens realizadas
+    viagem as (
+        select
+            data,
+            servico_realizado as servico,
+            datetime_partida,
+            datetime_chegada,
+            id_veiculo,
+            id_viagem,
+            distancia_planejada
+        from {{ ref("viagem_completa") }}
+        -- rj-smtr.projeto_subsidio_sppo.viagem_completa
+        where
+            data
+            between date_sub(date("{{ var('start_date') }}"), interval 1 day) and date(
+                "{{ var('end_date') }}"
+            )
+    ),
+    -- 5. Status dos veículos
+    veiculos as (
+        select data, id_veiculo, status
+        from {{ ref("sppo_veiculo_dia") }}
+        -- rj-smtr.veiculo.sppo_veiculo_dia
+        where
+            data
+            between date("{{ var('start_date') }}") and date("{{ var('end_date') }}")
+    ),
+    -- 6. Viagem, para fins de contagem de passageiros, com tolerância de 30 minutos,
+    -- limitada pela viagem anterior
+    viagem_com_tolerancia_previa as (
+        select
+            v.*,
+            lag(v.datetime_chegada) over (
+                partition by v.id_veiculo order by v.datetime_partida
+            ) as viagem_anterior_chegada,
+            case
+                when
+                    lag(v.datetime_chegada) over (
+                        partition by v.id_veiculo order by v.datetime_partida
+                    )
+                    is null
+                then datetime(timestamp_sub(datetime_partida, interval 30 minute))
+                else
+                    datetime(
+                        timestamp_add(
+                            greatest(
+                                timestamp_sub(datetime_partida, interval 30 minute),
+                                lag(v.datetime_chegada) over (
+                                    partition by v.id_veiculo
+                                    order by v.datetime_partida
+                                )
+                            ),
+                            interval 1 second
+                        )
+                    )
+            end as datetime_partida_com_tolerancia
+        from viagem as v
+    ),
+    -- 7. Considera apenas as viagens realizadas no período de apuração
+    viagem_com_tolerancia as (
+        select *
+        from viagem_com_tolerancia_previa
+        where
+            data
+            between date("{{ var('start_date') }}") and date("{{ var('end_date') }}")
+    ),
+    -- 8. Contagem de transações Jaé
+    transacao_contagem as (
+        select v.data, v.id_viagem, count(t.datetime_transacao) as quantidade_transacao
+        from transacao as t
+        join
+            viagem_com_tolerancia as v
+            on t.id_veiculo = substr(v.id_veiculo, 2)
+            and t.datetime_transacao
+            between v.datetime_partida_com_tolerancia and v.datetime_chegada
+        group by v.data, v.id_viagem
+    ),
+    -- 9. Contagem de transações RioCard
+    transacao_riocard_contagem as (
+        select
+            v.data,
+            v.id_viagem,
+            count(tr.datetime_transacao) as quantidade_transacao_riocard
+        from transacao_riocard as tr
+        join
+            viagem_com_tolerancia as v
+            on tr.id_veiculo = substr(v.id_veiculo, 2)
+            and tr.datetime_transacao
+            between v.datetime_partida_com_tolerancia and v.datetime_chegada
+        group by v.data, v.id_viagem
+    ),
+    -- 10. Ajusta estado do equipamento
+    -- Agrupa mesma posição para mesmo validador e veículo, mantendo preferencialmente
+    -- o estado do equipamento "ABERTO" quanto latitude e longitude for diferente de
+    -- (0,0)
+    estado_equipamento_aux as (
+        select *
+        from
+            (
+                (
+                    select
+                        data,
+                        id_validador,
+                        id_veiculo,
+                        latitude,
+                        longitude,
+                        if(
+                            count(case when estado_equipamento = "ABERTO" then 1 end)
+                            >= 1,
+                            "ABERTO",
+                            "FECHADO"
+                        ) as estado_equipamento,
+                        min(datetime_gps) as datetime_gps,
+                    from gps_validador
+                    where
+                        (
+                            data >= date("{{ var('DATA_SUBSIDIO_V12_INICIO') }}")
+                            and latitude != 0
+                            and longitude != 0
+                        )
+                        or data < date("{{ var('DATA_SUBSIDIO_V12_INICIO') }}")
+                    group by 1, 2, 3, 4, 5
+                )
+                union all
+                (
+                    select
+                        data,
+                        id_validador,
+                        id_veiculo,
+                        latitude,
+                        longitude,
+                        estado_equipamento,
+                        datetime_gps,
+                    from gps_validador
+                    where
+                        data >= date("{{ var('DATA_SUBSIDIO_V12_INICIO') }}")
+                        and latitude = 0
+                        and longitude = 0
+                )
+            )
+    ),
+    -- 11. Relacionamento entre estado do equipamento e viagem
+    gps_validador_viagem as (
+        select
+            v.data,
+            e.datetime_gps,
+            v.id_viagem,
+            e.id_validador,
+            e.estado_equipamento,
+            e.latitude,
+            e.longitude
+        from estado_equipamento_aux as e
+        join
+            viagem as v
+            on e.id_veiculo = substr(v.id_veiculo, 2)
+            and e.datetime_gps between v.datetime_partida and v.datetime_chegada
+    ),
+    -- 12. Calcula a porcentagem de estado do equipamento "ABERTO" por validador e
+    -- viagem
+    estado_equipamento_perc as (
+        select
+            data,
+            id_viagem,
+            id_validador,
+            countif(estado_equipamento = "ABERTO")
+            / count(*) as percentual_estado_equipamento_aberto
+        from gps_validador_viagem
+        group by 1, 2, 3
+    ),
+    -- 13. Considera o validador com maior porcentagem de estado do equipamento
+    -- "ABERTO" por viagem
+    estado_equipamento_max_perc as (
+        select
+            data,
+            id_viagem,
+            max_by(id_validador, percentual_estado_equipamento_aberto) as id_validador,
+            max(
+                percentual_estado_equipamento_aberto
+            ) as percentual_estado_equipamento_aberto
+        from estado_equipamento_perc
+        group by 1, 2
+    ),
+    -- 14. Verifica se a viagem possui estado do equipamento "ABERTO" em pelo menos
+    -- 80% dos registros
+    estado_equipamento_verificacao as (
+        select
+            data,
+            id_viagem,
+            id_validador,
+            percentual_estado_equipamento_aberto,
+            if(
+                percentual_estado_equipamento_aberto >= 0.8
+                or percentual_estado_equipamento_aberto is null,
+                true,
+                false
+            ) as indicador_estado_equipamento_aberto
+        from viagem
+        left join estado_equipamento_max_perc using (data, id_viagem)
+    )
+select
+    v.data,
+    v.id_viagem,
+    v.id_veiculo,
+    v.servico,
+    eev.id_validador,
+    case
+        when
+            v.data >= date("{{ var('DATA_SUBSIDIO_V8_INICIO') }}")
+            and (
+                (
+                    v.data < date("{{ var('DATA_SUBSIDIO_V12_INICIO') }}")
+                    and (
+                        coalesce(tr.quantidade_transacao_riocard, 0) = 0
+                        or coalesce(eev.indicador_estado_equipamento_aberto, false)
+                        = false
+                    )
+                )
+                or (
+                    v.data >= date("{{ var('DATA_SUBSIDIO_V12_INICIO') }}")
+                    and (
+                        (
+                            coalesce(tr.quantidade_transacao_riocard, 0) = 0
+                            and coalesce(t.quantidade_transacao, 0) = 0
+                        )
+                        or coalesce(eev.indicador_estado_equipamento_aberto, false)
+                        = false
+                    )
+                )
+            )
+            and ve.status
+            in ("Licenciado com ar e não autuado", "Licenciado sem ar e não autuado")
+            and v.datetime_partida not between "2024-10-06 06:00:00"
+            and "2024-10-06 20:00:00"  -- Eleição (2024-10-06)
+        then "Sem transação"
+        else ve.status
+    end as tipo_viagem,
+    v.distancia_planejada,
+    coalesce(t.quantidade_transacao, 0) as quantidade_transacao,
+    coalesce(tr.quantidade_transacao_riocard, 0) as quantidade_transacao_riocard,
+    eev.percentual_estado_equipamento_aberto,
+    eev.indicador_estado_equipamento_aberto,
+    v.datetime_partida_com_tolerancia as datetime_partida_bilhetagem,
+    v.datetime_partida,
+    v.datetime_chegada,
+    current_datetime("America/Sao_Paulo") as datetime_ultima_atualizacao
+from viagem_com_tolerancia as v
+left join veiculos as ve using (data, id_veiculo)
+left join transacao_contagem as t using (data, id_viagem)
+left join transacao_riocard_contagem as tr using (data, id_viagem)
+left join estado_equipamento_verificacao as eev using (data, id_viagem)


### PR DESCRIPTION
# Changelog - subsidio

## [2.0.0] - 2024-12-06

# Corrigido

- Corrigido e refatorado o modelo `viagem_transacao.sql`:
    - Reformatação conforme padrão `sqlfmt`
    - Passa a considerar registros de GPS do validador com coordenadas zeradas a partir de `DATA_SUBSIDIO_V12_INICIO`
    - Alterada janela de dados da CTE `viagem`, de forma a não ocorrer sobreposição entre viagens finalizadas na partição do dia anterior ao `start_date`
    - Passa a considerar uma transação RioCard ou Jaé para fins de validação do SBD a partir de `DATA_SUBSIDIO_V12_INICIO`