### PR TITLE
Bilhetagem - Altera IP do banco de tracking da Jaé

### DIFF
--- a/pipelines/capture/jae/CHANGELOG.md
+++ b/pipelines/capture/jae/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.0.1] - 2024-12-16
 
 ### Alterado
-- Altera IP do banco de tracking da Jaé
+- Altera IP do banco de tracking da Jaé (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/362)
 
 ## [1.0.0] - 2024-11-25
 

--- a/pipelines/capture/jae/CHANGELOG.md
+++ b/pipelines/capture/jae/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - source_jae
 
+## [1.0.1] - 2024-12-16
+
+### Alterado
+- Altera IP do banco de tracking da Jaé
+
 ## [1.0.0] - 2024-11-25
 
 ### Adicionado

--- a/pipelines/capture/jae/constants.py
+++ b/pipelines/capture/jae/constants.py
@@ -32,7 +32,7 @@ class constants(Enum):  # pylint: disable=c0103
         },
         "tracking_db": {
             "engine": "postgresql",
-            "host": "10.5.15.25",
+            "host": "10.5.12.67",
         },
         "ressarcimento_db": {
             "engine": "postgresql",

--- a/pipelines/constants.py
+++ b/pipelines/constants.py
@@ -172,7 +172,7 @@ class constants(Enum):  # pylint: disable=c0103
             },
             "tracking_db": {
                 "engine": "postgresql",
-                "host": "10.5.15.25",
+                "host": "10.5.12.67",
             },
             "ressarcimento_db": {
                 "engine": "postgresql",

--- a/pipelines/migration/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - br_rj_riodejaneiro_bilhetagem
 
+## [1.4.8] - 2024-12-16
+
+### Alterado
+- Altera IP do banco de tracking da Jaé
+
 ## [1.4.7] - 2024-09-16
 
 ### Alterado

--- a/pipelines/migration/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.4.8] - 2024-12-16
 
 ### Alterado
-- Altera IP do banco de tracking da Jaé
+- Altera IP do banco de tracking da Jaé (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/362)
 
 ## [1.4.7] - 2024-09-16
 


### PR DESCRIPTION
# Changelog - br_rj_riodejaneiro_bilhetagem

## [1.4.8] - 2024-12-16

### Alterado
- Altera IP do banco de tracking da Jaé

# Changelog - source_jae

## [1.0.1] - 2024-12-16

### Alterado
- Altera IP do banco de tracking da Jaé