### PR TITLE
Altera o tipo_os para verao

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT: 2024-12-13
+DBT: 2024-12-18
 """
 
 from prefect import Parameter, case, task

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Alterado o tipo os de `2024-12-07`, `2024-12-08`, `2024-12-14` e `2024-12-15` para `Extraordinária - Verão` no modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+- Alterado o tipo os de `2024-12-07`, `2024-12-08`, `2024-12-14` e `2024-12-15` para `Extraordinária - Verão` no modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/365)
 
 ## [9.1.1] - 2024-12-13
 

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - projeto_subsidio_sppo
 
+## [9.1.2] - 2024-12-18
+
+### Alterado
+
+- Alterado o tipo os de `2024-12-07`, `2024-12-08`, `2024-12-14` e `2024-12-15` para `Extraordinária - Verão` no modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+
 ## [9.1.1] - 2024-12-13
 
 ### Adicionado

--- a/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
+++ b/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
@@ -357,6 +357,8 @@ WITH
       WHEN data = DATE(2024,11,03) THEN "Enem"
       WHEN data = DATE(2024,11,10) THEN "Enem"
       WHEN data = DATE(2024,11,24) THEN "Parada LGBTQI+" -- Processo.Rio MTR-DES-2024/70057
+      WHEN data BETWEEN DATE(2024,12,07) AND DATE(2024,12,08) THEN "Extraordinária - Verão" -- Processo.Rio MTR-DES-2024/72800
+      WHEN data BETWEEN DATE(2024,12,14) AND DATE(2024,12,15) THEN "Extraordinária - Verão" -- Processo.Rio MTR-DES-2024/74396
       ELSE "Regular"
     END AS tipo_os,
   FROM UNNEST(GENERATE_DATE_ARRAY("{{var('DATA_SUBSIDIO_V6_INICIO')}}", "2024-12-31")) AS data),


### PR DESCRIPTION
# Changelog - projeto_subsidio_sppo

## [9.1.2] - 2024-12-18

### Alterado

- Alterado o tipo os de `2024-12-07`, `2024-12-08`, `2024-12-14` e `2024-12-15` para `Extraordinária - Verão` no modelo `subsidio_data_versao_efetiva.sql`