### PR TITLE
Altera regras de vistoria

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/CHANGELOG.md
+++ b/pipelines/migration/projeto_subsidio_sppo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Remove parâmetro `stu_data_versao` do flow `subsidio_sppo_apuracao` ()
+- Remove parâmetro `stu_data_versao` do flow `subsidio_sppo_apuracao` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/395)
 
 ## [1.0.8] - 2025-01-03
 

--- a/pipelines/migration/projeto_subsidio_sppo/CHANGELOG.md
+++ b/pipelines/migration/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog - projeto_subsidio_sppo
 
-## [1.0.9] - 2025-01-22
+## [1.0.9] - 2025-01-23
 
 ### Alterado
 

--- a/pipelines/migration/projeto_subsidio_sppo/CHANGELOG.md
+++ b/pipelines/migration/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog - projeto_subsidio_sppo
 
+## [1.0.9] - 2025-01-22
+
+### Alterado
+
+- Remove parâmetro `stu_data_versao` do flow `subsidio_sppo_apuracao` ()
+
 ## [1.0.8] - 2025-01-03
 
 ### Corrigido
 
-- corrigida a materialização dos modelos do dataset `monitoramento` no flow do subsídio (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/391)
+- Corrigida a materialização dos modelos do dataset `monitoramento` no flow do subsídio (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/391)
 
 ## [1.0.7] - 2025-01-03
 

--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -147,7 +147,6 @@ with Flow(
 
     end_date = merge(end_date_get, end_date_def)
 
-    stu_data_versao = Parameter("stu_data_versao", default="")
     materialize_sppo_veiculo_dia = Parameter("materialize_sppo_veiculo_dia", True)
     test_only = Parameter("test_only", False)
     # publish = Parameter("publish", False)
@@ -182,7 +181,6 @@ with Flow(
             parameters = {
                 "start_date": start_date,
                 "end_date": end_date,
-                "stu_data_versao": stu_data_versao,
             }
 
             SPPO_VEICULO_DIA_RUN = create_flow_run(

--- a/pipelines/migration/veiculo/CHANGELOG.md
+++ b/pipelines/migration/veiculo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - veiculo
 
+## [1.1.1] - 2025-01-22
+
+### Alterado
+- Remove parâmetro `stu_data_versao` do flow `sppo_veiculo_dia` ()
+
 ## [1.1.0] - 2025-01-16
 
 ### Alterado

--- a/pipelines/migration/veiculo/CHANGELOG.md
+++ b/pipelines/migration/veiculo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog - veiculo
 
-## [1.1.1] - 2025-01-22
+## [1.1.1] - 2025-01-23
 
 ### Alterado
 - Remove parâmetro `stu_data_versao` do flow `sppo_veiculo_dia` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/395)

--- a/pipelines/migration/veiculo/CHANGELOG.md
+++ b/pipelines/migration/veiculo/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.1.1] - 2025-01-22
 
 ### Alterado
-- Remove parâmetro `stu_data_versao` do flow `sppo_veiculo_dia` ()
+- Remove parâmetro `stu_data_versao` do flow `sppo_veiculo_dia` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/395)
 
 ## [1.1.0] - 2025-01-16
 

--- a/pipelines/migration/veiculo/flows.py
+++ b/pipelines/migration/veiculo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for veiculos
 
-DBT: 2025-01-21
+DBT: 2025-01-22
 """
 
 from copy import deepcopy
@@ -223,7 +223,6 @@ with Flow(
     # Get default parameters #
     start_date = Parameter("start_date", default=get_previous_date.run(1))
     end_date = Parameter("end_date", default=get_previous_date.run(1))
-    stu_data_versao = Parameter("stu_data_versao", default="")
 
     run_dates = get_run_dates(start_date, end_date)
 
@@ -243,8 +242,7 @@ with Flow(
         dataset_id=smtr_constants.VEICULO_DATASET_ID.value,
     )
 
-    dict_list = get_join_dict(dict_list=run_dates, new_dict=dataset_sha)
-    _vars = get_join_dict(dict_list=dict_list, new_dict={"stu_data_versao": stu_data_versao})
+    _vars = get_join_dict(dict_list=run_dates, new_dict=dataset_sha)
 
     # 2. TREAT #
     run_dbt_model.map(

--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -154,7 +154,6 @@ vars:
   sppo_infracao_staging: "rj-smtr-staging.veiculo_staging.sppo_infracao"
   sppo_registro_agente_verao_staging: "rj-smtr-staging.veiculo_staging.sppo_registro_agente_verao"
   sppo_licenciamento_solicitacao_data_versao: "2023-02-06"
-  stu_data_versao: ""
   # Prazo para última vistoria realizada dentro do período válido
   sppo_licenciamento_validade_vistoria_ano: 1
   # Tolerância de vistoria para veículos novos

--- a/queries/macros/get_license_date.sql
+++ b/queries/macros/get_license_date.sql
@@ -1,19 +1,32 @@
 {% macro get_license_date() %}
-SELECT
-  CASE
-    {% if var("stu_data_versao") != "" %}
-    WHEN "{{ var('stu_data_versao') }}" != "" THEN DATE("{{ var('stu_data_versao') }}")
-    {% endif %}
-    --- Versão fixa do STU em 2024-03-25 para mar/Q1 devido à falha de atualização na fonte da dados (SIURB)
-    WHEN DATE("{{ var('run_date') }}") >= "2024-03-01" AND DATE("{{ var('run_date') }}") < "2024-03-16" THEN DATE("2024-03-25")
-    -- Versão fixa do STU em 2024-04-09 para mar/Q2 devido à falha de atualização na fonte da dados (SIURB)
-    WHEN DATE("{{ var('run_date') }}") >= "2024-03-16" AND DATE("{{ var('run_date') }}") < "2024-04-01" THEN DATE("2024-04-09")
-    ELSE (
-      SELECT MIN(DATE(data))
-      FROM {{ ref("licenciamento_stu_staging") }}
-      WHERE DATE(data) >= DATE_ADD(DATE("{{ var('run_date') }}"), INTERVAL 5 DAY)
-        -- Admite apenas versões do STU igual ou após 2024-04-09 a partir de abril/24 devido à falha de atualização na fonte da dados (SIURB)
-        AND (DATE("{{ var('run_date') }}") < "2024-04-01" OR DATE(data) >= '2024-04-09')
-    )
-  END
+    select
+        case
+            -- - Versão fixa do STU em 2024-03-25 para mar/Q1 devido à falha de
+            -- atualização na fonte da dados (SIURB)
+            when
+                date("{{ var('run_date') }}") >= "2024-03-01"
+                and date("{{ var('run_date') }}") < "2024-03-16"
+            then date("2024-03-25")
+            -- Versão fixa do STU em 2024-04-09 para mar/Q2 devido à falha de
+            -- atualização na fonte da dados (SIURB)
+            when
+                date("{{ var('run_date') }}") >= "2024-03-16"
+                and date("{{ var('run_date') }}") < "2024-04-01"
+            then date("2024-04-09")
+            else
+                (
+                    select min(date(data))
+                    from {{ ref("licenciamento_stu_staging") }}
+                    where
+                        date(data)
+                        >= date_add(date("{{ var('run_date') }}"), interval 5 day)
+                        -- Admite apenas versões do STU igual ou após 2024-04-09 a
+                        -- partir de abril/24 devido à falha de atualização na fonte
+                        -- da dados (SIURB)
+                        and (
+                            date("{{ var('run_date') }}") < "2024-04-01"
+                            or date(data) >= '2024-04-09'
+                        )
+                )
+        end
 {% endmacro %}

--- a/queries/macros/get_license_date.sql
+++ b/queries/macros/get_license_date.sql
@@ -1,14 +1,14 @@
 {% macro get_license_date() %}
     select
         case
-            -- - Versão fixa do STU em 2024-03-25 para mar/Q1 devido à falha de
-            -- atualização na fonte da dados (SIURB)
+            /* Versão fixa do STU em 2024-03-25 para mar/Q1 devido à falha de
+             atualização na fonte da dados (SIURB) */
             when
                 date("{{ var('run_date') }}") >= "2024-03-01"
                 and date("{{ var('run_date') }}") < "2024-03-16"
             then date("2024-03-25")
-            -- Versão fixa do STU em 2024-04-09 para mar/Q2 devido à falha de
-            -- atualização na fonte da dados (SIURB)
+            /* Versão fixa do STU em 2024-04-09 para mar/Q2 devido à falha de
+             atualização na fonte da dados (SIURB) */
             when
                 date("{{ var('run_date') }}") >= "2024-03-16"
                 and date("{{ var('run_date') }}") < "2024-04-01"
@@ -20,9 +20,9 @@
                     where
                         date(data)
                         >= date_add(date("{{ var('run_date') }}"), interval 5 day)
-                        -- Admite apenas versões do STU igual ou após 2024-04-09 a
-                        -- partir de abril/24 devido à falha de atualização na fonte
-                        -- da dados (SIURB)
+                        /* Admite apenas versões do STU igual ou após 2024-04-09 a
+                         partir de abril/24 devido à falha de atualização na fonte
+                         de dados (SIURB) */
                         and (
                             date("{{ var('run_date') }}") < "2024-04-01"
                             or date(data) >= '2024-04-09'

--- a/queries/models/veiculo/CHANGELOG.md
+++ b/queries/models/veiculo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - veiculo
 
+## [2.0.2] - 2025-01-22
+
+### Alterado
+- Encerrada regra de transição com dados temporários da CGLF no modelo `licenciamento.sql` e reformatação deste ()
+
 ## [2.0.1] - 2025-01-21
 
 ### Corrigido

--- a/queries/models/veiculo/CHANGELOG.md
+++ b/queries/models/veiculo/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [2.0.2] - 2025-01-22
 
 ### Alterado
-- Encerrada regra de transição com dados temporários da CGLF no modelo `licenciamento.sql` e reformatação deste ()
+- Encerrada regra de transição com dados temporários da CGLF no modelo `licenciamento.sql` e reformatação deste (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/395)
 
 ## [2.0.1] - 2025-01-21
 

--- a/queries/models/veiculo/CHANGELOG.md
+++ b/queries/models/veiculo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog - veiculo
 
-## [2.0.2] - 2025-01-22
+## [2.0.2] - 2025-01-23
 
 ### Alterado
 - Encerrada regra de transição com dados temporários da CGLF no modelo `licenciamento.sql` e reformatação deste (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/395)

--- a/queries/models/veiculo/CHANGELOG.md
+++ b/queries/models/veiculo/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Alterado
 - Encerrada regra de transição com dados temporários da CGLF no modelo `licenciamento.sql` e reformatação deste (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/395)
 
+### Corrigido
+- Corrigidos os tipos das colunas `tecnologia`, `placa`, `data_licenciamento` e `data_infracao` na materialização antes de `2025-01-01` no modelo `sppo_veiculo_dia.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/395)
+
 ## [2.0.1] - 2025-01-21
 
 ### Corrigido

--- a/queries/models/veiculo/licenciamento.sql
+++ b/queries/models/veiculo/licenciamento.sql
@@ -87,6 +87,6 @@ select
     data_inicio_vinculo,
     ano_ultima_vistoria_atualizado,
     current_datetime("America/Sao_Paulo") as datetime_ultima_atualizacao,
-    "{{ var(" version ") }}" as versao
+    "{{ var('version') }}" as versao
 from stu_ano_ultima_vistoria
 where rn = 1

--- a/queries/models/veiculo/licenciamento.sql
+++ b/queries/models/veiculo/licenciamento.sql
@@ -1,96 +1,92 @@
 -- depends_on: {{ ref('aux_sppo_licenciamento_vistoria_atualizada') }}
 {{
-  config(
-    materialized="incremental",
-    partition_by={"field": "data", "data_type": "date", "granularity": "day"},
-    unique_key=["data", "id_veiculo"],
-    incremental_strategy="insert_overwrite",
-  )
+    config(
+        materialized="incremental",
+        partition_by={"field": "data", "data_type": "date", "granularity": "day"},
+        unique_key=["data", "id_veiculo"],
+        incremental_strategy="insert_overwrite",
+    )
 }}
 
 {% if execute and is_incremental() %}
-  {% set licenciamento_date = run_query(get_license_date()).columns[0].values()[0] %}
+    {% set licenciamento_date = run_query(get_license_date()).columns[0].values()[0] %}
 {% endif %}
 
-WITH stu AS (
-  SELECT
-    * EXCEPT(data),
-    DATE(data) AS data
-  FROM
-    {{ ref("licenciamento_stu_staging") }} AS t
-  {% if is_incremental() %}
-    WHERE
-      DATE(data) = DATE("{{ licenciamento_date }}")
-  {% endif %}
-),
-stu_rn AS (
-  SELECT
-    * EXCEPT (timestamp_captura),
-    EXTRACT(YEAR FROM data_ultima_vistoria) AS ano_ultima_vistoria,
-    ROW_NUMBER() OVER (PARTITION BY data, id_veiculo) rn
-  FROM
-    stu
-),
-stu_ano_ultima_vistoria AS (
-  -- Temporariamente considerando os dados de vistoria enviados pela TR/SUBTT/CGLF
-  SELECT
-    s.* EXCEPT(ano_ultima_vistoria),
-    CASE
-      WHEN data >= "2024-03-01" AND c.ano_ultima_vistoria > s.ano_ultima_vistoria THEN c.ano_ultima_vistoria
-      WHEN data >= "2024-03-01" THEN COALESCE(s.ano_ultima_vistoria, c.ano_ultima_vistoria)
-      ELSE s.ano_ultima_vistoria
-    END AS ano_ultima_vistoria_atualizado,
-  FROM
-    stu_rn AS s
-  LEFT JOIN
-  (
-    SELECT
-      id_veiculo,
-      placa,
-      ano_ultima_vistoria
-    FROM
-      {{ ref("aux_sppo_licenciamento_vistoria_atualizada") }}
-  ) AS c
-  USING(id_veiculo, placa)
-)
-SELECT
-  data,
-  modo,
-  id_veiculo,
-  ano_fabricacao,
-  carroceria,
-  data_ultima_vistoria,
-  id_carroceria,
-  id_chassi,
-  id_fabricante_chassi,
-  id_interno_carroceria,
-  id_planta,
-  indicador_ar_condicionado,
-  indicador_elevador,
-  indicador_usb,
-  indicador_wifi,
-  nome_chassi,
-  permissao,
-  placa,
-  CASE
-    WHEN tipo_veiculo LIKE "%BASIC%" OR tipo_veiculo LIKE "%BS%" THEN "BASICO"
-    WHEN tipo_veiculo LIKE "%MIDI%" THEN "MIDI"
-    WHEN tipo_veiculo LIKE "%MINI%" THEN "MINI"
-    WHEN tipo_veiculo LIKE "%PDRON%" OR tipo_veiculo LIKE "%PADRON%" THEN "PADRON"
-    WHEN tipo_veiculo LIKE "%ARTICULADO%" THEN "ARTICULADO"
-    ELSE NULL
-  END AS tecnologia,
-  quantidade_lotacao_pe,
-  quantidade_lotacao_sentado,
-  tipo_combustivel,
-  tipo_veiculo,
-  status,
-  data_inicio_vinculo,
-  ano_ultima_vistoria_atualizado,
-  CURRENT_DATETIME("America/Sao_Paulo") AS datetime_ultima_atualizacao,
-  "{{ var("version") }}" AS versao
-FROM
-  stu_ano_ultima_vistoria
-WHERE
-  rn = 1
-
+with
+    stu as (
+        select * except (data), date(data) as data
+        from {{ ref("licenciamento_stu_staging") }} as t
+        {% if is_incremental() %}
+            where date(data) = date("{{ licenciamento_date }}")
+        {% endif %}
+    ),
+    stu_rn as (
+        select
+            * except (timestamp_captura),
+            extract(year from data_ultima_vistoria) as ano_ultima_vistoria,
+            row_number() over (partition by data, id_veiculo) rn
+        from stu
+    ),
+    stu_ano_ultima_vistoria as (
+        -- Temporariamente considerando os dados de vistoria enviados pela TR/SUBTT/CGLF
+        select
+            s.* except (ano_ultima_vistoria),
+            case
+                when
+                    data between "2024-03-01" and "2024-12-31"
+                    and c.ano_ultima_vistoria > s.ano_ultima_vistoria
+                then c.ano_ultima_vistoria
+                when data between "2024-03-01" and "2024-12-31"
+                then coalesce(s.ano_ultima_vistoria, c.ano_ultima_vistoria)
+                else s.ano_ultima_vistoria
+            end as ano_ultima_vistoria_atualizado,
+        from stu_rn as s
+        left join
+            (
+                select id_veiculo, placa, ano_ultima_vistoria
+                from {{ ref("aux_sppo_licenciamento_vistoria_atualizada") }}
+            ) as c using (id_veiculo, placa)
+    )
+select
+    data,
+    modo,
+    id_veiculo,
+    ano_fabricacao,
+    carroceria,
+    data_ultima_vistoria,
+    id_carroceria,
+    id_chassi,
+    id_fabricante_chassi,
+    id_interno_carroceria,
+    id_planta,
+    indicador_ar_condicionado,
+    indicador_elevador,
+    indicador_usb,
+    indicador_wifi,
+    nome_chassi,
+    permissao,
+    placa,
+    case
+        when tipo_veiculo like "%BASIC%" or tipo_veiculo like "%BS%"
+        then "BASICO"
+        when tipo_veiculo like "%MIDI%"
+        then "MIDI"
+        when tipo_veiculo like "%MINI%"
+        then "MINI"
+        when tipo_veiculo like "%PDRON%" or tipo_veiculo like "%PADRON%"
+        then "PADRON"
+        when tipo_veiculo like "%ARTICULADO%"
+        then "ARTICULADO"
+        else null
+    end as tecnologia,
+    quantidade_lotacao_pe,
+    quantidade_lotacao_sentado,
+    tipo_combustivel,
+    tipo_veiculo,
+    status,
+    data_inicio_vinculo,
+    ano_ultima_vistoria_atualizado,
+    current_datetime("America/Sao_Paulo") as datetime_ultima_atualizacao,
+    "{{ var(" version ") }}" as versao
+from stu_ano_ultima_vistoria
+where rn = 1

--- a/queries/models/veiculo/sppo_veiculo_dia.sql
+++ b/queries/models/veiculo/sppo_veiculo_dia.sql
@@ -1,282 +1,332 @@
 -- depends_on: {{ ref('licenciamento_stu_staging') }}
 -- depends_on: {{ ref("infracao") }}
 {{
-  config(
-    materialized="incremental",
-    partition_by={"field": "data", "data_type": "date", "granularity": "day"},
-    unique_key=["data", "id_veiculo"],
-    incremental_strategy="insert_overwrite",
-  )
+    config(
+        materialized="incremental",
+        partition_by={"field": "data", "data_type": "date", "granularity": "day"},
+        unique_key=["data", "id_veiculo"],
+        incremental_strategy="insert_overwrite",
+    )
 }}
 
 {% if execute %}
-  {% set licenciamento_date = run_query(get_license_date()).columns[0].values()[0] %}
+    {% set licenciamento_date = run_query(get_license_date()).columns[0].values()[0] %}
 {% endif %}
 
-WITH licenciamento AS (
-  SELECT
-    DATE("{{ var('run_date') }}") AS data,
-    id_veiculo,
-    placa,
-    tipo_veiculo,
-    tecnologia,
-    indicador_ar_condicionado,
-    TRUE AS indicador_licenciado,
-    CASE
-      WHEN ano_ultima_vistoria_atualizado >= CAST(EXTRACT(YEAR FROM DATE_SUB(DATE("{{ var('run_date') }}"), INTERVAL {{ var('sppo_licenciamento_validade_vistoria_ano') }} YEAR)) AS INT64) THEN TRUE -- Última vistoria realizada dentro do período válido
-      WHEN data_ultima_vistoria IS NULL AND DATE_DIFF(DATE("{{ var('run_date') }}"), data_inicio_vinculo, DAY) <=  {{ var('sppo_licenciamento_tolerancia_primeira_vistoria_dia') }} THEN TRUE -- Caso o veículo seja novo, existe a tolerância de 15 dias para a primeira vistoria
-      WHEN ano_fabricacao IN (2023, 2024) AND CAST(EXTRACT(YEAR FROM DATE("{{ var('run_date') }}")) AS INT64) = 2024 THEN TRUE -- Caso o veículo tiver ano de fabricação 2023 ou 2024, será considerado como vistoriado apenas em 2024 (regra de transição)
-      ELSE FALSE
-    END AS indicador_vistoriado,
-    data_inicio_vinculo
-  FROM
-    {{ ref("sppo_licenciamento") }}
-  WHERE
-    data = DATE("{{ licenciamento_date }}")
-),
-gps AS (
-  SELECT
-    DISTINCT data,
-    id_veiculo
-  FROM
-    {{ ref("gps_sppo") }}
-    -- `rj-smtr.br_rj_riodejaneiro_veiculos.gps_sppo`
-  WHERE
-    data = DATE("{{ var('run_date') }}") ),
-  autuacoes AS (
-  SELECT
-    DISTINCT data_infracao AS data,
-    placa,
-    id_infracao
-  FROM
-     {{ ref("sppo_infracao") }}
-    --`rj-smtr.veiculo.sppo_infracao`
-  WHERE
-  {%- if execute %}
-    {% set infracao_date = run_query("SELECT MIN(data) FROM " ~ ref("infracao") ~ " WHERE data >= DATE_ADD(DATE('" ~ var("run_date") ~ "'), INTERVAL 7 DAY)").columns[0].values()[0] %}
-  {% endif -%}
-    data = DATE("{{ infracao_date }}")
-    AND data_infracao = DATE("{{ var('run_date') }}")
-),
-registros_agente_verao AS (
-  SELECT
-    DISTINCT data,
-    id_veiculo,
-    TRUE AS indicador_registro_agente_verao_ar_condicionado
-  FROM
-    {{ ref("sppo_registro_agente_verao") }}
-    -- `rj-smtr.veiculo.sppo_registro_agente_verao`
-  WHERE
-    data = DATE("{{ var('run_date') }}")
-),
-autuacao_ar_condicionado AS (
-  SELECT
-    data,
-    placa,
-    TRUE AS indicador_autuacao_ar_condicionado
-  FROM
-    autuacoes
-  WHERE
-    id_infracao = "023.II" ),
-  autuacao_seguranca AS (
-  SELECT
-    data,
-    placa,
-    TRUE AS indicador_autuacao_seguranca
-  FROM
-    autuacoes
-  WHERE
-    id_infracao IN (
-      "016.VI",
-      "023.VII",
-      "024.II",
-      "024.III",
-      "024.IV",
-      "024.V",
-      "024.VI",
-      "024.VII",
-      "024.VIII",
-      "024.IX",
-      "024.XII",
-      "024.XIV",
-      "024.XV",
-      "025.II",
-      "025.XII",
-      "025.XIII",
-      "025.XIV",
-      "026.X")
-),
-autuacao_equipamento AS (
-  SELECT
-    data,
-    placa,
-    TRUE AS indicador_autuacao_equipamento
-  FROM
-    autuacoes
-  WHERE
-    id_infracao IN (
-      "023.IV",
-      "023.V",
-      "023.VI",
-      "023.VIII",
-      "024.XIII",
-      "024.XI",
-      "024.XVIII",
-      "024.XXI",
-      "025.III",
-      "025.IV",
-      "025.V",
-      "025.VI",
-      "025.VII",
-      "025.VIII",
-      "025.IX",
-      "025.X",
-      "025.XI")
-),
-autuacao_limpeza AS (
-  SELECT
-    data,
-    placa,
-    TRUE AS indicador_autuacao_limpeza
-  FROM
-    autuacoes
-  WHERE
-    id_infracao IN (
-      "023.IX",
-      "024.X") ),
-  autuacoes_agg AS (
-  SELECT
-    DISTINCT *
-  FROM
-    autuacao_ar_condicionado
-  FULL JOIN
-    autuacao_seguranca
-  USING(data, placa)
-  FULL JOIN
-    autuacao_equipamento
-  USING(data, placa)
-  FULL JOIN
-    autuacao_limpeza
-  USING(data, placa)
-),
-gps_licenciamento_autuacao AS (
-  SELECT
-    data,
-    id_veiculo,
-    {% if var("run_date") >= var("DATA_SUBSIDIO_V5_INICIO") %}
-      STRUCT( COALESCE(l.indicador_licenciado, FALSE)                               AS indicador_licenciado,
-              COALESCE(l.indicador_vistoriado, FALSE)                               AS indicador_vistoriado,
-              COALESCE(l.indicador_ar_condicionado, FALSE)                          AS indicador_ar_condicionado,
-              COALESCE(a.indicador_autuacao_ar_condicionado, FALSE)                 AS indicador_autuacao_ar_condicionado,
-              COALESCE(a.indicador_autuacao_seguranca, FALSE)                       AS indicador_autuacao_seguranca,
-              COALESCE(a.indicador_autuacao_limpeza, FALSE)                         AS indicador_autuacao_limpeza,
-              COALESCE(a.indicador_autuacao_equipamento, FALSE)                     AS indicador_autuacao_equipamento,
-              COALESCE(r.indicador_registro_agente_verao_ar_condicionado, FALSE)    AS indicador_registro_agente_verao_ar_condicionado)
-      -- WHEN data >= DATE("DATA_SUBSIDIO_V4_INICIO") THEN
-      -- STRUCT( COALESCE(l.indicador_licenciado, FALSE)                     AS indicador_licenciado,
-      --         COALESCE(l.indicador_ar_condicionado, FALSE)                AS indicador_ar_condicionado,
-      --         COALESCE(a.indicador_autuacao_ar_condicionado, FALSE)       AS indicador_autuacao_ar_condicionado,
-      --         COALESCE(a.indicador_autuacao_seguranca, FALSE)             AS indicador_autuacao_seguranca,
-      --         COALESCE(a.indicador_autuacao_limpeza, FALSE)               AS indicador_autuacao_limpeza,
-      --         COALESCE(a.indicador_autuacao_equipamento, FALSE)           AS indicador_autuacao_equipamento,
-      --         COALESCE(r.indicador_registro_agente_verao_ar_condicionado, FALSE)   AS indicador_registro_agente_verao_ar_condicionado)
-      -- WHEN data >= DATE("DATA_SUBSIDIO_V3_INICIO") THEN
-      -- STRUCT( COALESCE(l.indicador_licenciado, FALSE)                     AS indicador_licenciado,
-      --         COALESCE(l.indicador_ar_condicionado, FALSE)                AS indicador_ar_condicionado,
-      --         COALESCE(a.indicador_autuacao_ar_condicionado, FALSE)       AS indicador_autuacao_ar_condicionado,
-      --         COALESCE(a.indicador_autuacao_seguranca, FALSE)             AS indicador_autuacao_seguranca,
-      --         COALESCE(a.indicador_autuacao_limpeza, FALSE)               AS indicador_autuacao_limpeza,
-      --         COALESCE(a.indicador_autuacao_equipamento, FALSE)           AS indicador_autuacao_equipamento)
-      -- WHEN data >= DATE("DATA_SUBSIDIO_V2_INICIO") THEN
-      -- STRUCT( COALESCE(l.indicador_licenciado, FALSE)                     AS indicador_licenciado,
-      --         COALESCE(l.indicador_ar_condicionado, FALSE)                AS indicador_ar_condicionado,
-      --         COALESCE(a.indicador_autuacao_ar_condicionado, FALSE)       AS indicador_autuacao_ar_condicionado)
-      -- ELSE
-      -- NULL
-    {% else %}
-      STRUCT( COALESCE(l.indicador_licenciado, FALSE)                     AS indicador_licenciado,
-              COALESCE(l.indicador_ar_condicionado, FALSE)                AS indicador_ar_condicionado,
-              COALESCE(a.indicador_autuacao_ar_condicionado, FALSE)       AS indicador_autuacao_ar_condicionado,
-              COALESCE(a.indicador_autuacao_seguranca, FALSE)             AS indicador_autuacao_seguranca,
-              COALESCE(a.indicador_autuacao_limpeza, FALSE)               AS indicador_autuacao_limpeza,
-              COALESCE(a.indicador_autuacao_equipamento, FALSE)           AS indicador_autuacao_equipamento,
-              COALESCE(r.indicador_registro_agente_verao_ar_condicionado, FALSE)   AS indicador_registro_agente_verao_ar_condicionado)
-    {% endif %}
-    AS indicadores,
-    l.placa,
-    tecnologia
-  FROM
-    gps g
-  LEFT JOIN
-    licenciamento AS l
-  USING(data, id_veiculo)
-  LEFT JOIN
-    autuacoes_agg AS a
-  USING(data, placa)
-  LEFT JOIN
-    registros_agente_verao AS r
-  USING(data, id_veiculo)
-)
+with
+    licenciamento as (
+        select
+            date("{{ var('run_date') }}") as data,
+            id_veiculo,
+            placa,
+            tipo_veiculo,
+            tecnologia,
+            indicador_ar_condicionado,
+            true as indicador_licenciado,
+            case
+                when
+                    ano_ultima_vistoria_atualizado >= cast(
+                        extract(
+                            year
+                            from
+                                date_sub(
+                                    date("{{ var('run_date') }}"),
+                                    interval {{
+                                        var(
+                                            "sppo_licenciamento_validade_vistoria_ano"
+                                        )
+                                    }} year
+                                )
+                        ) as int64
+                    )
+                then true  -- Última vistoria realizada dentro do período válido
+                when
+                    data_ultima_vistoria is null
+                    and date_diff(
+                        date("{{ var('run_date') }}"), data_inicio_vinculo, day
+                    )
+                    <= {{ var("sppo_licenciamento_tolerancia_primeira_vistoria_dia") }}
+                then true  -- Caso o veículo seja novo, existe a tolerância de 15 dias para a primeira vistoria
+                when
+                    ano_fabricacao in (2023, 2024)
+                    and cast(extract(year from date("{{ var('run_date') }}")) as int64)
+                    = 2024
+                then true  -- Caso o veículo tiver ano de fabricação 2023 ou 2024, será considerado como vistoriado apenas em 2024 (regra de transição)
+                else false
+            end as indicador_vistoriado,
+            data_inicio_vinculo
+        from {{ ref("sppo_licenciamento") }}
+        where data = date("{{ licenciamento_date }}")
+    ),
+    gps as (
+        select distinct data, id_veiculo
+        from -- {{ ref("gps_sppo") }}
+        `rj-smtr.br_rj_riodejaneiro_veiculos.gps_sppo`
+        where data = date("{{ var('run_date') }}")
+    ),
+    autuacoes as (
+        select distinct data_infracao as data, placa, id_infracao
+        from {{ ref("sppo_infracao") }}
+        -- `rj-smtr.veiculo.sppo_infracao`
+        where
+            {%- if execute %}
+                {% set infracao_date = (
+                    run_query(
+                        "SELECT MIN(data) FROM "
+                        ~ ref("infracao")
+                        ~ " WHERE data >= DATE_ADD(DATE('"
+                        ~ var("run_date")
+                        ~ "'), INTERVAL 7 DAY)"
+                    )
+                    .columns[0]
+                    .values()[0]
+                ) %}
+            {% endif -%}
+            data = date("{{ infracao_date }}")
+            and data_infracao = date("{{ var('run_date') }}")
+    ),
+    registros_agente_verao as (
+        select distinct
+            data, id_veiculo, true as indicador_registro_agente_verao_ar_condicionado
+        from {{ ref("sppo_registro_agente_verao") }}
+        -- `rj-smtr.veiculo.sppo_registro_agente_verao`
+        where data = date("{{ var('run_date') }}")
+    ),
+    autuacao_ar_condicionado as (
+        select data, placa, true as indicador_autuacao_ar_condicionado
+        from autuacoes
+        where id_infracao = "023.II"
+    ),
+    autuacao_seguranca as (
+        select data, placa, true as indicador_autuacao_seguranca
+        from autuacoes
+        where
+            id_infracao in (
+                "016.VI",
+                "023.VII",
+                "024.II",
+                "024.III",
+                "024.IV",
+                "024.V",
+                "024.VI",
+                "024.VII",
+                "024.VIII",
+                "024.IX",
+                "024.XII",
+                "024.XIV",
+                "024.XV",
+                "025.II",
+                "025.XII",
+                "025.XIII",
+                "025.XIV",
+                "026.X"
+            )
+    ),
+    autuacao_equipamento as (
+        select data, placa, true as indicador_autuacao_equipamento
+        from autuacoes
+        where
+            id_infracao in (
+                "023.IV",
+                "023.V",
+                "023.VI",
+                "023.VIII",
+                "024.XIII",
+                "024.XI",
+                "024.XVIII",
+                "024.XXI",
+                "025.III",
+                "025.IV",
+                "025.V",
+                "025.VI",
+                "025.VII",
+                "025.VIII",
+                "025.IX",
+                "025.X",
+                "025.XI"
+            )
+    ),
+    autuacao_limpeza as (
+        select data, placa, true as indicador_autuacao_limpeza
+        from autuacoes
+        where id_infracao in ("023.IX", "024.X")
+    ),
+    autuacoes_agg as (
+        select distinct *
+        from autuacao_ar_condicionado
+        full join autuacao_seguranca using (data, placa)
+        full join autuacao_equipamento using (data, placa)
+        full join autuacao_limpeza using (data, placa)
+    ),
+    gps_licenciamento_autuacao as (
+        select
+            data,
+            id_veiculo,
+            {% if var("run_date") >= var("DATA_SUBSIDIO_V5_INICIO") %}
+                struct(
+                    coalesce(l.indicador_licenciado, false) as indicador_licenciado,
+                    coalesce(l.indicador_vistoriado, false) as indicador_vistoriado,
+                    coalesce(
+                        l.indicador_ar_condicionado, false
+                    ) as indicador_ar_condicionado,
+                    coalesce(
+                        a.indicador_autuacao_ar_condicionado, false
+                    ) as indicador_autuacao_ar_condicionado,
+                    coalesce(
+                        a.indicador_autuacao_seguranca, false
+                    ) as indicador_autuacao_seguranca,
+                    coalesce(
+                        a.indicador_autuacao_limpeza, false
+                    ) as indicador_autuacao_limpeza,
+                    coalesce(
+                        a.indicador_autuacao_equipamento, false
+                    ) as indicador_autuacao_equipamento,
+                    coalesce(
+                        r.indicador_registro_agente_verao_ar_condicionado, false
+                    ) as indicador_registro_agente_verao_ar_condicionado
+                )
+            -- WHEN data >= DATE("DATA_SUBSIDIO_V4_INICIO") THEN
+            -- STRUCT( COALESCE(l.indicador_licenciado, FALSE)                     AS
+            -- indicador_licenciado,
+            -- COALESCE(l.indicador_ar_condicionado, FALSE)                AS
+            -- indicador_ar_condicionado,
+            -- COALESCE(a.indicador_autuacao_ar_condicionado, FALSE)       AS
+            -- indicador_autuacao_ar_condicionado,
+            -- COALESCE(a.indicador_autuacao_seguranca, FALSE)             AS
+            -- indicador_autuacao_seguranca,
+            -- COALESCE(a.indicador_autuacao_limpeza, FALSE)               AS
+            -- indicador_autuacao_limpeza,
+            -- COALESCE(a.indicador_autuacao_equipamento, FALSE)           AS
+            -- indicador_autuacao_equipamento,
+            -- COALESCE(r.indicador_registro_agente_verao_ar_condicionado, FALSE)   AS
+            -- indicador_registro_agente_verao_ar_condicionado)
+            -- WHEN data >= DATE("DATA_SUBSIDIO_V3_INICIO") THEN
+            -- STRUCT( COALESCE(l.indicador_licenciado, FALSE)                     AS
+            -- indicador_licenciado,
+            -- COALESCE(l.indicador_ar_condicionado, FALSE)                AS
+            -- indicador_ar_condicionado,
+            -- COALESCE(a.indicador_autuacao_ar_condicionado, FALSE)       AS
+            -- indicador_autuacao_ar_condicionado,
+            -- COALESCE(a.indicador_autuacao_seguranca, FALSE)             AS
+            -- indicador_autuacao_seguranca,
+            -- COALESCE(a.indicador_autuacao_limpeza, FALSE)               AS
+            -- indicador_autuacao_limpeza,
+            -- COALESCE(a.indicador_autuacao_equipamento, FALSE)           AS
+            -- indicador_autuacao_equipamento)
+            -- WHEN data >= DATE("DATA_SUBSIDIO_V2_INICIO") THEN
+            -- STRUCT( COALESCE(l.indicador_licenciado, FALSE)                     AS
+            -- indicador_licenciado,
+            -- COALESCE(l.indicador_ar_condicionado, FALSE)                AS
+            -- indicador_ar_condicionado,
+            -- COALESCE(a.indicador_autuacao_ar_condicionado, FALSE)       AS
+            -- indicador_autuacao_ar_condicionado)
+            -- ELSE
+            -- NULL
+            {% else %}
+                struct(
+                    coalesce(l.indicador_licenciado, false) as indicador_licenciado,
+                    coalesce(
+                        l.indicador_ar_condicionado, false
+                    ) as indicador_ar_condicionado,
+                    coalesce(
+                        a.indicador_autuacao_ar_condicionado, false
+                    ) as indicador_autuacao_ar_condicionado,
+                    coalesce(
+                        a.indicador_autuacao_seguranca, false
+                    ) as indicador_autuacao_seguranca,
+                    coalesce(
+                        a.indicador_autuacao_limpeza, false
+                    ) as indicador_autuacao_limpeza,
+                    coalesce(
+                        a.indicador_autuacao_equipamento, false
+                    ) as indicador_autuacao_equipamento,
+                    coalesce(
+                        r.indicador_registro_agente_verao_ar_condicionado, false
+                    ) as indicador_registro_agente_verao_ar_condicionado
+                )
+            {% endif %} as indicadores,
+            l.placa,
+            tecnologia
+        from gps g
+        left join licenciamento as l using (data, id_veiculo)
+        left join autuacoes_agg as a using (data, placa)
+        left join registros_agente_verao as r using (data, id_veiculo)
+    )
 {% if var("run_date") < var("DATA_SUBSIDIO_V5_INICIO") %}
-SELECT
-  gla.* EXCEPT(indicadores, tecnologia, placa),
-  TO_JSON(indicadores) AS indicadores,
-  status,
-  {% if var("run_date") >= var("DATA_SUBSIDIO_V13_INICIO") %}
-    tecnologia,
-    placa,
-    DATE("{{ licenciamento_date }}") AS data_licenciamento,
-    DATE("{{ infracao_date }}") AS data_infracao,
-  {% else %}
-    null as tecnologia,
-    null as placa,
-    null as data_licenciamento,
-    null as data_infracao,
-  {% endif %}
-  CURRENT_DATETIME("America/Sao_Paulo") AS datetime_ultima_atualizacao,
-  "{{ var("version") }}" AS versao
-FROM
-  gps_licenciamento_autuacao AS gla
-LEFT JOIN
-  {{ ref("subsidio_parametros") }} AS p
-  -- `rj-smtr.dashboard_subsidio_sppo.subsidio_parametros` AS p
-ON
-  gla.indicadores.indicador_licenciado = p.indicador_licenciado
-  AND gla.indicadores.indicador_ar_condicionado = p.indicador_ar_condicionado
-  AND gla.indicadores.indicador_autuacao_ar_condicionado = p.indicador_autuacao_ar_condicionado
-  AND gla.indicadores.indicador_autuacao_seguranca = p.indicador_autuacao_seguranca
-  AND gla.indicadores.indicador_autuacao_limpeza = p.indicador_autuacao_limpeza
-  AND gla.indicadores.indicador_autuacao_equipamento = p.indicador_autuacao_equipamento
-  AND gla.indicadores.indicador_registro_agente_verao_ar_condicionado = p.indicador_registro_agente_verao_ar_condicionado
-  AND (data BETWEEN p.data_inicio AND p.data_fim)
+    select
+        gla.* except (indicadores, tecnologia, placa),
+        to_json(indicadores) as indicadores,
+        status,
+        {% if var("run_date") >= var("DATA_SUBSIDIO_V13_INICIO") %}
+            tecnologia,
+            placa,
+            date("{{ licenciamento_date }}") as data_licenciamento,
+            date("{{ infracao_date }}") as data_infracao,
+        {% else %}
+            safe_cast(null as string) as tecnologia,
+            safe_cast(null as string) as placa,
+            safe_cast(null as date) as data_licenciamento,
+            safe_cast(null as date) as data_infracao,
+        {% endif %}
+        current_datetime("America/Sao_Paulo") as datetime_ultima_atualizacao,
+        "{{ var('version') }}" as versao
+    from gps_licenciamento_autuacao as gla
+    left join
+        {{ ref("subsidio_parametros") }} as p
+        -- `rj-smtr.dashboard_subsidio_sppo.subsidio_parametros` AS p
+        on gla.indicadores.indicador_licenciado = p.indicador_licenciado
+        and gla.indicadores.indicador_ar_condicionado = p.indicador_ar_condicionado
+        and gla.indicadores.indicador_autuacao_ar_condicionado
+        = p.indicador_autuacao_ar_condicionado
+        and gla.indicadores.indicador_autuacao_seguranca
+        = p.indicador_autuacao_seguranca
+        and gla.indicadores.indicador_autuacao_limpeza = p.indicador_autuacao_limpeza
+        and gla.indicadores.indicador_autuacao_equipamento
+        = p.indicador_autuacao_equipamento
+        and gla.indicadores.indicador_registro_agente_verao_ar_condicionado
+        = p.indicador_registro_agente_verao_ar_condicionado
+        and (data between p.data_inicio and p.data_fim)
 {% else %}
-SELECT
-  * EXCEPT(indicadores, tecnologia, placa),
-  TO_JSON(indicadores) AS indicadores,
-  CASE
-    WHEN indicadores.indicador_licenciado IS FALSE THEN "Não licenciado"
-    WHEN indicadores.indicador_vistoriado IS FALSE THEN "Não vistoriado"
-    WHEN indicadores.indicador_ar_condicionado IS TRUE AND indicadores.indicador_autuacao_ar_condicionado IS TRUE THEN "Autuado por ar inoperante"
-    WHEN indicadores.indicador_ar_condicionado IS TRUE AND indicadores.indicador_registro_agente_verao_ar_condicionado IS TRUE THEN "Registrado com ar inoperante"
-    WHEN indicadores.indicador_autuacao_seguranca IS TRUE THEN "Autuado por segurança"
-    WHEN indicadores.indicador_autuacao_limpeza IS TRUE AND indicadores.indicador_autuacao_equipamento IS TRUE THEN "Autuado por limpeza/equipamento"
-    WHEN indicadores.indicador_ar_condicionado IS FALSE THEN "Licenciado sem ar e não autuado"
-    WHEN indicadores.indicador_ar_condicionado IS TRUE THEN "Licenciado com ar e não autuado"
-    ELSE NULL
-  END AS status,
-  {% if var("run_date") >= var("DATA_SUBSIDIO_V13_INICIO") %}
-    tecnologia,
-    placa,
-    DATE("{{ licenciamento_date }}") AS data_licenciamento,
-    DATE("{{ infracao_date }}") AS data_infracao,
-  {% else %}
-    null as tecnologia,
-    null as placa,
-    null as data_licenciamento,
-    null as data_infracao,
-  {% endif %}
-  CURRENT_DATETIME("America/Sao_Paulo") AS datetime_ultima_atualizacao,
-  "{{ var("version") }}" AS versao
-FROM
-  gps_licenciamento_autuacao
+    select
+        * except (indicadores, tecnologia, placa),
+        to_json(indicadores) as indicadores,
+        case
+            when indicadores.indicador_licenciado is false
+            then "Não licenciado"
+            when indicadores.indicador_vistoriado is false
+            then "Não vistoriado"
+            when
+                indicadores.indicador_ar_condicionado is true
+                and indicadores.indicador_autuacao_ar_condicionado is true
+            then "Autuado por ar inoperante"
+            when
+                indicadores.indicador_ar_condicionado is true
+                and indicadores.indicador_registro_agente_verao_ar_condicionado is true
+            then "Registrado com ar inoperante"
+            when indicadores.indicador_autuacao_seguranca is true
+            then "Autuado por segurança"
+            when
+                indicadores.indicador_autuacao_limpeza is true
+                and indicadores.indicador_autuacao_equipamento is true
+            then "Autuado por limpeza/equipamento"
+            when indicadores.indicador_ar_condicionado is false
+            then "Licenciado sem ar e não autuado"
+            when indicadores.indicador_ar_condicionado is true
+            then "Licenciado com ar e não autuado"
+            else null
+        end as status,
+        {% if var("run_date") >= var("DATA_SUBSIDIO_V13_INICIO") %}
+            tecnologia,
+            placa,
+            date("{{ licenciamento_date }}") as data_licenciamento,
+            date("{{ infracao_date }}") as data_infracao,
+        {% else %}
+            safe_cast(null as string) as tecnologia,
+            safe_cast(null as string) as placa,
+            safe_cast(null as date) as data_licenciamento,
+            safe_cast(null as date) as data_infracao,
+        {% endif %}
+        current_datetime("America/Sao_Paulo") as datetime_ultima_atualizacao,
+        "{{ var('version') }}" as versao
+    from gps_licenciamento_autuacao
 {% endif %}


### PR DESCRIPTION
# Flows
## Changelog - projeto_subsidio_sppo

### [1.0.9] - 2025-01-22

#### Alterado

- Remove parâmetro `stu_data_versao` do flow `subsidio_sppo_apuracao`

## Changelog - veiculo

### [1.1.1] - 2025-01-22

#### Alterado
- Remove parâmetro `stu_data_versao` do flow `sppo_veiculo_dia`

# Queries
## Changelog - veiculo

### [2.0.2] - 2025-01-22

#### Alterado
- Encerrada regra de transição com dados temporários da CGLF no modelo `licenciamento.sql` e reformatação deste