### PR TITLE
Altera os dias `2025-01-11` e `2025-01-12` para tipo_dia `Verão`

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT: 2025-01-06
+DBT: 2025-01-23
 """
 
 from prefect import Parameter, case, task

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Adicionado
 
+- Altera os dias `2025-01-11` e `2025-01-12` para tipo_dia `Verão` ao modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+
+## [9.1.5] - 2025-01-08
+
+### Adicionado
+
 - Adicionado label `dashboard` ao modelo `viagem_completa.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/258)
 
 ## [9.1.4] - 2025-01-06

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog - projeto_subsidio_sppo
 
-## [9.1.5] - 2025-01-08
+## [9.1.6] - 2025-01-23
 
 ### Adicionado
 

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Adicionado
 
-- Altera os dias `2025-01-11` e `2025-01-12` para tipo_dia `Verão` ao modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+- Altera os dias `2025-01-11` e `2025-01-12` para tipo_dia `Verão` ao modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/398)
 
 ## [9.1.5] - 2025-01-08
 

--- a/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
+++ b/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
@@ -366,6 +366,7 @@ WITH
       WHEN data = DATE(2024,12,31) THEN "Vespera de Reveillon" -- Processo.Rio MTR-DES-2024/76453
       WHEN data = DATE(2025,01,01) THEN "Reveillon" -- Processo.Rio MTR-DES-2024/76453
       WHEN data BETWEEN DATE(2025,01,02) AND DATE(2025,01,03) THEN "Fim de ano" -- Processo.Rio MTR-DES-2024/77046
+      WHEN data BETWEEN DATE(2025,01,11) AND DATE(2025,01,12) THEN "Extraordinária - Verão" -- Processo.Rio MTR-DES-2025/00831
       ELSE "Regular"
     END AS tipo_os,
   FROM UNNEST(GENERATE_DATE_ARRAY("{{var('DATA_SUBSIDIO_V6_INICIO')}}", "2025-12-31")) AS data),


### PR DESCRIPTION
# Changelog - projeto_subsidio_sppo

## [9.1.5] - 2025-01-08

### Adicionado

- Altera os dias `2025-01-11` e `2025-01-12` para tipo_dia `Verão` ao modelo `subsidio_data_versao_efetiva.sql`