### PR TITLE
Altera tipo_dia `Verão` no modelo `subsidio_data_versao_efetiva.sql` 

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT: 2025-02-03
+DBT: 2025-02-05
 """
 
 from prefect import Parameter, case, task

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Adicionado
 
-- Altera os dias `2025-01-18`, `2025-01-19`, `2025-01-20`,  `2025-01-25` e `2025-01-26` para tipo_dia `Verão` no modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+- Altera os dias `2025-01-18`, `2025-01-19`, `2025-01-20`,  `2025-01-25` e `2025-01-26` para tipo_dia `Verão` no modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/416)
 
 ## [9.1.6] - 2025-01-23
 

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog - projeto_subsidio_sppo
 
+## [9.1.7] - 2025-02-05
+
+### Adicionado
+
+- Altera os dias `2025-01-18`, `2025-01-19`, `2025-01-20`,  `2025-01-25` e `2025-01-26` para tipo_dia `Verão` no modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+
 ## [9.1.6] - 2025-01-23
 
 ### Adicionado
 
-- Altera os dias `2025-01-11` e `2025-01-12` para tipo_dia `Verão` ao modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/398)
+- Altera os dias `2025-01-11` e `2025-01-12` para tipo_dia `Verão` no modelo `subsidio_data_versao_efetiva.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/398)
 
 ## [9.1.5] - 2025-01-08
 

--- a/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
+++ b/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
@@ -368,7 +368,6 @@ WITH
       WHEN data BETWEEN DATE(2025,01,02) AND DATE(2025,01,03) THEN "Fim de ano" -- Processo.Rio MTR-DES-2024/77046
       WHEN data BETWEEN DATE(2025,01,11) AND DATE(2025,01,12) THEN "Extraordinária - Verão" -- Processo.Rio MTR-DES-2025/00831
       WHEN data BETWEEN DATE(2025,01,18) AND DATE(2025,01,20) THEN "Extraordinária - Verão" -- Processo.Rio MTR-DES-2025/01760 e MTR-DES-2025/02195
-
       WHEN data BETWEEN DATE(2025,01,25) AND DATE(2025,01,26) THEN "Extraordinária - Verão" -- Processo.Rio MTR-DES-2025/01468
       ELSE "Regular"
     END AS tipo_os,

--- a/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
+++ b/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
@@ -367,7 +367,8 @@ WITH
       WHEN data = DATE(2025,01,01) THEN "Reveillon" -- Processo.Rio MTR-DES-2024/76453
       WHEN data BETWEEN DATE(2025,01,02) AND DATE(2025,01,03) THEN "Fim de ano" -- Processo.Rio MTR-DES-2024/77046
       WHEN data BETWEEN DATE(2025,01,11) AND DATE(2025,01,12) THEN "Extraordinária - Verão" -- Processo.Rio MTR-DES-2025/00831
-      WHEN data BETWEEN DATE(2025,01,18) AND DATE(2025,01,20) THEN "Extraordinária - Verão" -- Processo.Rio MTR-DES-2025/01760
+      WHEN data BETWEEN DATE(2025,01,18) AND DATE(2025,01,20) THEN "Extraordinária - Verão" -- Processo.Rio MTR-DES-2025/01760 e MTR-DES-2025/02195
+
       WHEN data BETWEEN DATE(2025,01,25) AND DATE(2025,01,26) THEN "Extraordinária - Verão" -- Processo.Rio MTR-DES-2025/01468
       ELSE "Regular"
     END AS tipo_os,

--- a/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
+++ b/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
@@ -367,6 +367,8 @@ WITH
       WHEN data = DATE(2025,01,01) THEN "Reveillon" -- Processo.Rio MTR-DES-2024/76453
       WHEN data BETWEEN DATE(2025,01,02) AND DATE(2025,01,03) THEN "Fim de ano" -- Processo.Rio MTR-DES-2024/77046
       WHEN data BETWEEN DATE(2025,01,11) AND DATE(2025,01,12) THEN "Extraordinária - Verão" -- Processo.Rio MTR-DES-2025/00831
+      WHEN data BETWEEN DATE(2025,01,18) AND DATE(2025,01,20) THEN "Extraordinária - Verão" -- Processo.Rio MTR-DES-2025/01760
+      WHEN data BETWEEN DATE(2025,01,25) AND DATE(2025,01,26) THEN "Extraordinária - Verão" -- Processo.Rio MTR-DES-2025/01468
       ELSE "Regular"
     END AS tipo_os,
   FROM UNNEST(GENERATE_DATE_ARRAY("{{var('DATA_SUBSIDIO_V6_INICIO')}}", "2025-12-31")) AS data),


### PR DESCRIPTION
# Changelog - projeto_subsidio_sppo

## [9.1.7] - 2025-02-05

### Adicionado

- Altera os dias `2025-01-18`, `2025-01-19`, `2025-01-20`,  `2025-01-25` e `2025-01-26` para tipo_dia `Verão` ao modelo `subsidio_data_versao_efetiva.sql`