### PR TITLE
Adiciona novos campos na constante `SPPO_LICENCIAMENTO_MAPPING_KEYS`

### DIFF
--- a/pipelines/migration/veiculo/CHANGELOG.md
+++ b/pipelines/migration/veiculo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - veiculo
 
+## [1.1.4] - 2025-02-10
+
+### Adicionado
+- Adicionados novos campos na constante `SPPO_LICENCIAMENTO_MAPPING_KEYS` conforme novo leiaute informado pela IPLANRIO/PRE/DPN/GTIS-6 por e-mail em 2025-02-10 (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/420)
+
 ## [1.1.3] - 2025-02-06
 
 ### Adicionado

--- a/pipelines/migration/veiculo/constants.py
+++ b/pipelines/migration/veiculo/constants.py
@@ -39,6 +39,8 @@ class constants(Enum):  # pylint: disable=c0103
         "wifi": "indicador_wifi",
         "usb": "indicador_usb",
         "data_inicio_vinculo": "data_inicio_vinculo",
+        "situacao": "situacao",
+        "ano_ultima_vistoria": "ano_ultima_vistoria",
     }
 
     SPPO_LICENCIAMENTO_CSV_ARGS = {

--- a/pipelines/migration/veiculo/constants.py
+++ b/pipelines/migration/veiculo/constants.py
@@ -39,7 +39,7 @@ class constants(Enum):  # pylint: disable=c0103
         "wifi": "indicador_wifi",
         "usb": "indicador_usb",
         "data_inicio_vinculo": "data_inicio_vinculo",
-        "situacao": "situacao",
+        "ultima_situacao": "ultima_situacao",
         "ano_ultima_vistoria": "ano_ultima_vistoria",
     }
 


### PR DESCRIPTION
# Changelog - veiculo

## [1.1.4] - 2025-02-10

### Adicionado
- Adicionados novos campos na constante `SPPO_LICENCIAMENTO_MAPPING_KEYS` conforme novo leiaute informado pela IPLANRIO/PRE/DPN/GTIS-6 por e-mail em 2025-02-10