### PR TITLE
Torna o filtro de partição obrigatório em tabelas grandes

### DIFF
--- a/pipelines/capture/jae/constants.py
+++ b/pipelines/capture/jae/constants.py
@@ -78,10 +78,10 @@ class constants(Enum):  # pylint: disable=c0103
             "engine": "postgresql",
             "host": "10.5.113.179",
         },
-        "iam_db": {
-            "engine": "mysql",
-            "host": "10.5.13.201",
-        },
+        # "iam_db": {
+        #     "engine": "mysql",
+        #     "host": "10.5.13.201",
+        # },
         "vendas_db": {
             "engine": "postgresql",
             "host": "10.5.113.30",
@@ -454,21 +454,21 @@ class constants(Enum):  # pylint: disable=c0103
                 "cnab_transaction": ["count(*)"],
             },
         },
-        "iam_db": {
-            "exclude": [
-                "gratuidade_import_pcd",
-                "CLIENTE_FRAUDE_05092024",
-            ],
-            "filter": {
-                "CONTROLE_CODIGO_VERIFICACAO": ["NR_SEQ"],
-                "PERFIL_ACESSO": ["DT_INCLUSAO", "DT_CANCELAMENTO"],
-                "SEGURANCA_CONTA_ACESSO": ["DT_INCLUSAO"],
-                "CONTA_ACESSO": ["DT_EXPIRACAO", "DT_INCLUSAO"],
-                "ATIVACAO_CONTA_ACESSO": ["CRIADO_EM", "DT_ATIVACAO"],
-                "CONTA_ACESSO_BACK": ["DT_EXPIRACAO", "DT_INCLUSAO"],
-                "check_cadastro_pcd_validado": ["data_nascimento"],
-            },
-        },
+        # "iam_db": {
+        #     "exclude": [
+        #         "gratuidade_import_pcd",
+        #         "CLIENTE_FRAUDE_05092024",
+        #     ],
+        #     "filter": {
+        #         "CONTROLE_CODIGO_VERIFICACAO": ["NR_SEQ"],
+        #         "PERFIL_ACESSO": ["DT_INCLUSAO", "DT_CANCELAMENTO"],
+        #         "SEGURANCA_CONTA_ACESSO": ["DT_INCLUSAO"],
+        #         "CONTA_ACESSO": ["DT_EXPIRACAO", "DT_INCLUSAO"],
+        #         "ATIVACAO_CONTA_ACESSO": ["CRIADO_EM", "DT_ATIVACAO"],
+        #         "CONTA_ACESSO_BACK": ["DT_EXPIRACAO", "DT_INCLUSAO"],
+        #         "check_cadastro_pcd_validado": ["data_nascimento"],
+        #     },
+        # },
         "vendas_db": {
             "filter": {
                 "venda": [

--- a/pipelines/constants.py
+++ b/pipelines/constants.py
@@ -2,7 +2,7 @@
 """
 Valores constantes gerais para pipelines da rj-smtr
 
-DBT 2025-02-13
+DBT 2025-02-21
 """
 
 from enum import Enum

--- a/queries/models/br_rj_riodejaneiro_brt_gps/CHANGELOG.md
+++ b/queries/models/br_rj_riodejaneiro_brt_gps/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.0.1] - 2025-02-21
 
 ### Alterado
-- Torna filtro de partição obrigatório no modelo `brt_aux_registros_filtrada.sql`
+- Torna filtro de partição obrigatório no modelo `brt_aux_registros_filtrada.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/448)
 
 ## [1.0.0] - 2024-07-02
 

--- a/queries/models/br_rj_riodejaneiro_brt_gps/CHANGELOG.md
+++ b/queries/models/br_rj_riodejaneiro_brt_gps/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - brt_gps
 
+## [1.0.1] - 2025-02-21
+
+### Alterado
+- Torna filtro de partição obrigatório no modelo `brt_aux_registros_filtrada.sql`
+
 ## [1.0.0] - 2024-07-02
 
 ### Adicionado

--- a/queries/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_filtrada.sql
+++ b/queries/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_filtrada.sql
@@ -1,12 +1,9 @@
 {{
-  config(
-      materialized='incremental',
-      partition_by={
-            "field":"data",
-            "data_type": "date",
-            "granularity":"day"
-      }
-  )
+    config(
+        materialized="incremental",
+        partition_by={"field": "data", "data_type": "date", "granularity": "day"},
+        require_partition_filter=true,
+    )
 }}
 /*
 - Descrição:
@@ -16,56 +13,52 @@ Filtragem e tratamento básico de registros de gps.
 2. Filtra registros que estão fora de uma caixa que contém a área do
    município de Rio de Janeiro.
 */
-WITH
-box AS (
-  /*1. Geometria de caixa que contém a área do município de Rio de Janeiro.*/
-	SELECT
-	*
-	FROM
-	{{ var('limites_caixa') }}),
-gps AS (
-  /* 1. Filtra registros antigos. Remove registros que tem diferença maior
-   que 1 minuto entre o timestamp_captura e timestamp_gps.*/
-  SELECT
-    *,
-    ST_GEOGPOINT(longitude, latitude) posicao_veiculo_geo
-  FROM
-    {{ ref('brt_registros_desaninhada') }}
-  {% if is_incremental() -%}
-  WHERE
-    data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-    AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <= "{{var('date_range_end')}}"
-    AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
-  {%- endif %}
+with
+    box as (
+        /* 1. Geometria de caixa que contém a área do município de Rio de Janeiro.*/
+        select * from {{ var("limites_caixa") }}
     ),
-filtrada AS (
-  /* 2. Filtra registros que estão fora de uma caixa que contém a área do
+    gps as (
+        /* 1. Filtra registros antigos. Remove registros que tem diferença maior
+   que 1 minuto entre o timestamp_captura e timestamp_gps.*/
+        select *, st_geogpoint(longitude, latitude) posicao_veiculo_geo
+        from {{ ref("brt_registros_desaninhada") }}
+        {% if is_incremental() -%}
+            where
+                data between date("{{var('date_range_start')}}") and date(
+                    "{{var('date_range_end')}}"
+                )
+                and timestamp_gps > "{{var('date_range_start')}}"
+                and timestamp_gps <= "{{var('date_range_end')}}"
+                and datetime_diff(timestamp_captura, timestamp_gps, minute)
+                between 0 and 1
+        {%- endif %}
+    ),
+    filtrada as (
+        /* 2. Filtra registros que estão fora de uma caixa que contém a área do
    município de Rio de Janeiro.*/
-  SELECT
-    id_veiculo,
-    latitude,
-    longitude,
-    posicao_veiculo_geo,
-    velocidade,
-    servico,
-    timestamp_gps,
-    timestamp_captura,
-    data,
-    hora,
-    row_number() over (partition by id_veiculo, timestamp_gps, servico) rn
-  FROM
-    gps
-  WHERE
-    ST_INTERSECTSBOX(posicao_veiculo_geo,
-      ( SELECT min_longitude FROM box),
-      ( SELECT min_latitude FROM box),
-      ( SELECT max_longitude FROM box),
-      ( SELECT max_latitude FROM box))
-  )
-SELECT
-  * except(rn),
-  "{{ var("version") }}" as versao
-FROM
-  filtrada
-WHERE
-  rn = 1
+        select
+            id_veiculo,
+            latitude,
+            longitude,
+            posicao_veiculo_geo,
+            velocidade,
+            servico,
+            timestamp_gps,
+            timestamp_captura,
+            data,
+            hora,
+            row_number() over (partition by id_veiculo, timestamp_gps, servico) rn
+        from gps
+        where
+            st_intersectsbox(
+                posicao_veiculo_geo,
+                (select min_longitude from box),
+                (select min_latitude from box),
+                (select max_longitude from box),
+                (select max_latitude from box)
+            )
+    )
+select * except (rn), "{{ var(" version ") }}" as versao
+from filtrada
+where rn = 1

--- a/queries/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_filtrada.sql
+++ b/queries/models/br_rj_riodejaneiro_brt_gps/brt_aux_registros_filtrada.sql
@@ -59,6 +59,6 @@ with
                 (select max_latitude from box)
             )
     )
-select * except (rn), "{{ var(" version ") }}" as versao
+select * except (rn), '{{ var("version") }}' as versao
 from filtrada
 where rn = 1

--- a/queries/models/br_rj_riodejaneiro_onibus_gps/CHANGELOG.md
+++ b/queries/models/br_rj_riodejaneiro_onibus_gps/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.0.3] - 2025-02-21
 
 ### Alterado
-- Torna filtro de partição obrigatório no modelo `sppo_aux_registros_filtrada.sql`
+- Torna filtro de partição obrigatório no modelo `sppo_aux_registros_filtrada.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/448)
 
 ## [1.0.2] - 2024-11-13
 

--- a/queries/models/br_rj_riodejaneiro_onibus_gps/CHANGELOG.md
+++ b/queries/models/br_rj_riodejaneiro_onibus_gps/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - br_rj_riodejaneiro_onibus_gps
 
+## [1.0.3] - 2025-02-21
+
+### Alterado
+- Torna filtro de partição obrigatório no modelo `sppo_aux_registros_filtrada.sql`
 
 ## [1.0.2] - 2024-11-13
 

--- a/queries/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_filtrada.sql
+++ b/queries/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_filtrada.sql
@@ -1,23 +1,20 @@
 {% if var("fifteen_minutes") == "_15_minutos" %}
-{{
-  config(
-      materialized='ephemeral',
-  )
-}}
+    {{
+        config(
+            materialized="ephemeral",
+        )
+    }}
 {% else %}
-{{
-  config(
-      materialized='incremental',
-      partition_by={
-            "field":"data",
-            "data_type": "date",
-            "granularity":"day"
-      }
-  )
-}}
+    {{
+        config(
+            materialized="incremental",
+            partition_by={"field": "data", "data_type": "date", "granularity": "day"},
+            require_partition_filter=true,
+        )
+    }}
 {% endif %}
 
-  /*
+/*
 Descrição:
 Filtragem e tratamento básico de registros de gps.
 1. Filtra registros que estão fora de uma caixa que contém a área do município de Rio de Janeiro.
@@ -25,66 +22,56 @@ Filtragem e tratamento básico de registros de gps.
 3. Muda o nome de variáveis para o padrão do projeto.
 	- id_veiculo --> ordem
 */
-WITH
-box AS (
-  /*1. Geometria de caixa que contém a área do município de Rio de Janeiro.*/
-	SELECT
-	*
-	FROM
-	{{ var('limites_caixa') }}
-),
-gps AS (
-  /*2. Filtra registros antigos. Remove registros que tem diferença maior que 1 minuto entre o timestamp_captura e timestamp_gps.*/
-  SELECT
-    *,
-    ST_GEOGPOINT(longitude, latitude) posicao_veiculo_geo
-  FROM
-    {{ ref('sppo_registros') }}
-  WHERE
-    data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-  {% if is_incremental() -%}
-    AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
-  {%- endif -%}
-),
-realocacao as (
-  SELECT
-    g.* except(linha),
-    coalesce(r.servico_realocado, g.linha) as linha
-  FROM
-    gps g
-  LEFT JOIN
-    {{ ref('sppo_aux_registros_realocacao') }} r
-  ON
-    g.ordem = r.id_veiculo
-    and g.timestamp_gps = r.timestamp_gps
-),
-filtrada AS (
-  /*1,2, e 3. Muda o nome de variáveis para o padrão do projeto.*/
-  SELECT
-    ordem AS id_veiculo,
-    latitude,
-    longitude,
-    posicao_veiculo_geo,
-    velocidade,
-    linha,
-    timestamp_gps,
-    timestamp_captura,
-    data,
-    hora,
-    row_number() over (partition by ordem, timestamp_gps, linha) rn
-  FROM
-    realocacao
-  WHERE
-    ST_INTERSECTSBOX(posicao_veiculo_geo,
-      ( SELECT min_longitude FROM box),
-      ( SELECT min_latitude FROM box),
-      ( SELECT max_longitude FROM box),
-      ( SELECT max_latitude FROM box))
-  )
-SELECT
-  * except(rn),
-  "{{ var("version") }}" as versao
-FROM
-  filtrada
-WHERE
-  rn = 1
+with
+    box as (
+        /* 1. Geometria de caixa que contém a área do município de Rio de Janeiro.*/
+        select * from {{ var("limites_caixa") }}
+    ),
+    gps as (
+        /* 2. Filtra registros antigos. Remove registros que tem diferença maior que 1 minuto entre o timestamp_captura e timestamp_gps.*/
+        select *, st_geogpoint(longitude, latitude) posicao_veiculo_geo
+        from {{ ref("sppo_registros") }}
+        where
+            data between date("{{var('date_range_start')}}") and date(
+                "{{var('date_range_end')}}"
+            )
+            {% if is_incremental() -%}
+                and timestamp_gps > "{{var('date_range_start')}}"
+                and timestamp_gps <= "{{var('date_range_end')}}"
+            {%- endif -%}
+    ),
+    realocacao as (
+        select g.* except (linha), coalesce(r.servico_realocado, g.linha) as linha
+        from gps g
+        left join
+            {{ ref("sppo_aux_registros_realocacao") }} r
+            on g.ordem = r.id_veiculo
+            and g.timestamp_gps = r.timestamp_gps
+    ),
+    filtrada as (
+        /* 1,2, e 3. Muda o nome de variáveis para o padrão do projeto.*/
+        select
+            ordem as id_veiculo,
+            latitude,
+            longitude,
+            posicao_veiculo_geo,
+            velocidade,
+            linha,
+            timestamp_gps,
+            timestamp_captura,
+            data,
+            hora,
+            row_number() over (partition by ordem, timestamp_gps, linha) rn
+        from realocacao
+        where
+            st_intersectsbox(
+                posicao_veiculo_geo,
+                (select min_longitude from box),
+                (select min_latitude from box),
+                (select max_longitude from box),
+                (select max_latitude from box)
+            )
+    )
+select * except (rn), "{{ var(" version ") }}" as versao
+from filtrada
+where rn = 1

--- a/queries/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_filtrada.sql
+++ b/queries/models/br_rj_riodejaneiro_onibus_gps/sppo_aux_registros_filtrada.sql
@@ -72,6 +72,6 @@ with
                 (select max_latitude from box)
             )
     )
-select * except (rn), "{{ var(" version ") }}" as versao
+select * except (rn), "{{ var('version') }}" as versao
 from filtrada
 where rn = 1

--- a/queries/models/br_rj_riodejaneiro_onibus_gps_zirix/CHANGELOG.md
+++ b/queries/models/br_rj_riodejaneiro_onibus_gps_zirix/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.0.5] - 2025-02-21
 
 ### Alterado
-- Torna filtro de partição obrigatório nos modelos `sppo_aux_registros_filtrada_zirix.sql` e `gps_sppo_zirix.sql`
+- Torna filtro de partição obrigatório nos modelos `sppo_aux_registros_filtrada_zirix.sql` e `gps_sppo_zirix.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/448)
 
 ## [1.0.4] - 2024-08-09
 

--- a/queries/models/br_rj_riodejaneiro_onibus_gps_zirix/CHANGELOG.md
+++ b/queries/models/br_rj_riodejaneiro_onibus_gps_zirix/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - onibus_gps_zirix
 
+## [1.0.5] - 2025-02-21
+
+### Alterado
+- Torna filtro de partição obrigatório nos modelos `sppo_aux_registros_filtrada_zirix.sql` e `gps_sppo_zirix.sql`
+
 ## [1.0.4] - 2024-08-09
 
 ### Adicionado

--- a/queries/models/br_rj_riodejaneiro_onibus_gps_zirix/gps_sppo_zirix.sql
+++ b/queries/models/br_rj_riodejaneiro_onibus_gps_zirix/gps_sppo_zirix.sql
@@ -1,14 +1,11 @@
 {{
-  config(
-    materialized='incremental',
-    partition_by={
-      'field':"data",
-      'data_type':'date',
-      'granularity': 'day'
-    },
-    alias='gps_sppo',
-    tags=['geolocalizacao']
-  )
+    config(
+        materialized="incremental",
+        partition_by={"field": "data", "data_type": "date", "granularity": "day"},
+        alias="gps_sppo",
+        tags=["geolocalizacao"],
+        require_partition_filter=true,
+    )
 }}
 /*
 Descrição:
@@ -24,118 +21,116 @@ do estado de movimento ('parado', 'andando')
 com o traçado da linha informada.
 5. As junções (joins) são feitas sobre o id_veículo e a timestamp_gps.
 */
-WITH
-  registros as (
-  -- 1. registros_filtrada
-    SELECT
-      id_veiculo,
-      timestamp_gps,
-      timestamp_captura,
-      velocidade,
-      linha,
-      latitude,
-      longitude,
-    FROM {{ ref('sppo_aux_registros_filtrada_zirix') }}
-    {% if is_incremental() -%}
-    WHERE
-      data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-      AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
-    {%- endif -%}
-  ),
-  velocidades AS (
-    -- 2. velocidades
-    SELECT
-      id_veiculo, timestamp_gps, linha, velocidade, distancia, flag_em_movimento
-    FROM
-      {{ ref('sppo_aux_registros_velocidade_zirix') }}
-  ),
-  paradas as (
-    -- 3. paradas
-    SELECT
-      id_veiculo, timestamp_gps, linha, tipo_parada,
-    FROM {{ ref('sppo_aux_registros_parada_zirix') }}
-  ),
-  flags AS (
-    -- 4. flag_trajeto_correto
-    SELECT
-      id_veiculo,
-      timestamp_gps,
-      linha,
-      route_id,
-      flag_linha_existe_sigmob,
-      flag_trajeto_correto,
-      flag_trajeto_correto_hist
-    FROM
-      {{ ref('sppo_aux_registros_flag_trajeto_correto_zirix') }}
-  )
+with
+    registros as (
+        -- 1. registros_filtrada
+        select
+            id_veiculo,
+            timestamp_gps,
+            timestamp_captura,
+            velocidade,
+            linha,
+            latitude,
+            longitude,
+        from {{ ref("sppo_aux_registros_filtrada_zirix") }}
+        {% if is_incremental() -%}
+            where
+                data between date("{{var('date_range_start')}}") and date(
+                    "{{var('date_range_end')}}"
+                )
+                and timestamp_gps > "{{var('date_range_start')}}"
+                and timestamp_gps <= "{{var('date_range_end')}}"
+        {%- endif -%}
+    ),
+    velocidades as (
+        -- 2. velocidades
+        select
+            id_veiculo, timestamp_gps, linha, velocidade, distancia, flag_em_movimento
+        from {{ ref("sppo_aux_registros_velocidade_zirix") }}
+    ),
+    paradas as (
+        -- 3. paradas
+        select id_veiculo, timestamp_gps, linha, tipo_parada,
+        from {{ ref("sppo_aux_registros_parada_zirix") }}
+    ),
+    flags as (
+        -- 4. flag_trajeto_correto
+        select
+            id_veiculo,
+            timestamp_gps,
+            linha,
+            route_id,
+            flag_linha_existe_sigmob,
+            flag_trajeto_correto,
+            flag_trajeto_correto_hist
+        from {{ ref("sppo_aux_registros_flag_trajeto_correto_zirix") }}
+    )
 -- 5. Junção final
-SELECT
-  "SPPO" modo,
-  r.timestamp_gps,
-  date(r.timestamp_gps) data,
-  extract(time from r.timestamp_gps) hora,
-  r.id_veiculo,
-  r.linha as servico,
-  r.latitude,
-  r.longitude,
-  CASE
-    WHEN
-      flag_em_movimento IS true AND flag_trajeto_correto_hist is true
-      THEN true
-  ELSE false
-  END flag_em_operacao,
-  v.flag_em_movimento,
-  p.tipo_parada,
-  flag_linha_existe_sigmob,
-  flag_trajeto_correto,
-  flag_trajeto_correto_hist,
-  CASE
-    WHEN flag_em_movimento IS true AND flag_trajeto_correto_hist is true
-    THEN 'Em operação'
-    WHEN flag_em_movimento is true and flag_trajeto_correto_hist is false
-    THEN 'Operando fora trajeto'
-    WHEN flag_em_movimento is false
-    THEN
-        CASE
-            WHEN tipo_parada is not null
-            THEN concat("Parado ", tipo_parada)
-        ELSE
-            CASE
-                WHEN flag_trajeto_correto_hist is true
-                THEN 'Parado trajeto correto'
-            ELSE 'Parado fora trajeto'
-            END
-        END
-    END status,
-  r.velocidade velocidade_instantanea,
-  v.velocidade velocidade_estimada_10_min,
-  v.distancia,
-  "{{ var("version") }}" as versao
-FROM
-  registros r
+select
+    "SPPO" modo,
+    r.timestamp_gps,
+    date(r.timestamp_gps) data,
+    extract(time from r.timestamp_gps) hora,
+    r.id_veiculo,
+    r.linha as servico,
+    r.latitude,
+    r.longitude,
+    case
+        when flag_em_movimento is true and flag_trajeto_correto_hist is true
+        then true
+        else false
+    end flag_em_operacao,
+    v.flag_em_movimento,
+    p.tipo_parada,
+    flag_linha_existe_sigmob,
+    flag_trajeto_correto,
+    flag_trajeto_correto_hist,
+    case
+        when flag_em_movimento is true and flag_trajeto_correto_hist is true
+        then 'Em operação'
+        when flag_em_movimento is true and flag_trajeto_correto_hist is false
+        then 'Operando fora trajeto'
+        when flag_em_movimento is false
+        then
+            case
+                when tipo_parada is not null
+                then concat("Parado ", tipo_parada)
+                else
+                    case
+                        when flag_trajeto_correto_hist is true
+                        then 'Parado trajeto correto'
+                        else 'Parado fora trajeto'
+                    end
+            end
+    end status,
+    r.velocidade velocidade_instantanea,
+    v.velocidade velocidade_estimada_10_min,
+    v.distancia,
+    "{{ var(" version ") }}" as versao
+from registros r
 
-JOIN
-  flags f
-ON
-  r.id_veiculo = f.id_veiculo
-  AND r.timestamp_gps = f.timestamp_gps
-  AND r.linha = f.linha
+join
+    flags f
+    on r.id_veiculo = f.id_veiculo
+    and r.timestamp_gps = f.timestamp_gps
+    and r.linha = f.linha
 
-JOIN
-  velocidades v
-ON
-  r.id_veiculo = v.id_veiculo
-  AND  r.timestamp_gps = v.timestamp_gps
-  AND  r.linha = v.linha
+join
+    velocidades v
+    on r.id_veiculo = v.id_veiculo
+    and r.timestamp_gps = v.timestamp_gps
+    and r.linha = v.linha
 
-JOIN
-  paradas p
-ON
-  r.id_veiculo = p.id_veiculo
-  AND  r.timestamp_gps = p.timestamp_gps
-  AND r.linha = p.linha
+join
+    paradas p
+    on r.id_veiculo = p.id_veiculo
+    and r.timestamp_gps = p.timestamp_gps
+    and r.linha = p.linha
 {% if is_incremental() -%}
-  WHERE
-  date(r.timestamp_gps) between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-  AND r.timestamp_gps > "{{var('date_range_start')}}" and r.timestamp_gps <="{{var('date_range_end')}}"
+    where
+        date(r.timestamp_gps) between date("{{var('date_range_start')}}") and date(
+            "{{var('date_range_end')}}"
+        )
+        and r.timestamp_gps > "{{var('date_range_start')}}"
+        and r.timestamp_gps <= "{{var('date_range_end')}}"
 {%- endif -%}

--- a/queries/models/br_rj_riodejaneiro_onibus_gps_zirix/gps_sppo_zirix.sql
+++ b/queries/models/br_rj_riodejaneiro_onibus_gps_zirix/gps_sppo_zirix.sql
@@ -106,7 +106,7 @@ select
     r.velocidade velocidade_instantanea,
     v.velocidade velocidade_estimada_10_min,
     v.distancia,
-    "{{ var(" version ") }}" as versao
+    "{{ var('version') }}" as versao
 from registros r
 
 join

--- a/queries/models/br_rj_riodejaneiro_onibus_gps_zirix/sppo_aux_registros_filtrada_zirix.sql
+++ b/queries/models/br_rj_riodejaneiro_onibus_gps_zirix/sppo_aux_registros_filtrada_zirix.sql
@@ -1,15 +1,12 @@
 {{
-  config(
-      materialized='incremental',
-      partition_by={
-            "field":"data",
-            "data_type": "date",
-            "granularity":"day"
-      },
-      alias='sppo_aux_registro_filtrada'
-  )
+    config(
+        materialized="incremental",
+        partition_by={"field": "data", "data_type": "date", "granularity": "day"},
+        alias="sppo_aux_registro_filtrada",
+        require_partition_filter=true,
+    )
 }}
-  /*
+/*
 Descrição:
 Filtragem e tratamento básico de registros de gps.
 1. Filtra registros que estão fora de uma caixa que contém a área do município de Rio de Janeiro.
@@ -17,66 +14,56 @@ Filtragem e tratamento básico de registros de gps.
 3. Muda o nome de variáveis para o padrão do projeto.
 	- id_veiculo --> ordem
 */
-WITH
-box AS (
-  /*1. Geometria de caixa que contém a área do município de Rio de Janeiro.*/
-	SELECT
-	*
-	FROM
-	{{ var('limites_caixa') }}
-),
-gps AS (
-  /*2. Filtra registros antigos. Remove registros que tem diferença maior que 1 minuto entre o timestamp_captura e timestamp_gps.*/
-  SELECT
-    *,
-    ST_GEOGPOINT(longitude, latitude) posicao_veiculo_geo
-  FROM
-    {{ ref('sppo_registros_zirix') }}
-  {% if is_incremental() -%}
-  WHERE
-    data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-    AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
-  {%- endif -%}
-),
-realocacao as (
-  SELECT
-    g.* except(linha),
-    coalesce(r.servico_realocado, g.linha) as linha
-  FROM
-    gps g
-  LEFT JOIN
-    {{ ref('sppo_aux_registros_realocacao_zirix') }} r
-  ON
-    g.ordem = r.id_veiculo
-    and g.timestamp_gps = r.timestamp_gps
-),
-filtrada AS (
-  /*1,2, e 3. Muda o nome de variáveis para o padrão do projeto.*/
-  SELECT
-    ordem AS id_veiculo,
-    latitude,
-    longitude,
-    posicao_veiculo_geo,
-    velocidade,
-    linha,
-    timestamp_gps,
-    timestamp_captura,
-    data,
-    hora,
-    row_number() over (partition by ordem, timestamp_gps, linha) rn
-  FROM
-    realocacao
-  WHERE
-    ST_INTERSECTSBOX(posicao_veiculo_geo,
-      ( SELECT min_longitude FROM box),
-      ( SELECT min_latitude FROM box),
-      ( SELECT max_longitude FROM box),
-      ( SELECT max_latitude FROM box))
-  )
-SELECT
-  * except(rn),
-  "{{ var("version") }}" as versao
-FROM
-  filtrada
-WHERE
-  rn = 1
+with
+    box as (
+        /* 1. Geometria de caixa que contém a área do município de Rio de Janeiro.*/
+        select * from {{ var("limites_caixa") }}
+    ),
+    gps as (
+        /* 2. Filtra registros antigos. Remove registros que tem diferença maior que 1 minuto entre o timestamp_captura e timestamp_gps.*/
+        select *, st_geogpoint(longitude, latitude) posicao_veiculo_geo
+        from {{ ref("sppo_registros_zirix") }}
+        {% if is_incremental() -%}
+            where
+                data between date("{{var('date_range_start')}}") and date(
+                    "{{var('date_range_end')}}"
+                )
+                and timestamp_gps > "{{var('date_range_start')}}"
+                and timestamp_gps <= "{{var('date_range_end')}}"
+        {%- endif -%}
+    ),
+    realocacao as (
+        select g.* except (linha), coalesce(r.servico_realocado, g.linha) as linha
+        from gps g
+        left join
+            {{ ref("sppo_aux_registros_realocacao_zirix") }} r
+            on g.ordem = r.id_veiculo
+            and g.timestamp_gps = r.timestamp_gps
+    ),
+    filtrada as (
+        /* 1,2, e 3. Muda o nome de variáveis para o padrão do projeto.*/
+        select
+            ordem as id_veiculo,
+            latitude,
+            longitude,
+            posicao_veiculo_geo,
+            velocidade,
+            linha,
+            timestamp_gps,
+            timestamp_captura,
+            data,
+            hora,
+            row_number() over (partition by ordem, timestamp_gps, linha) rn
+        from realocacao
+        where
+            st_intersectsbox(
+                posicao_veiculo_geo,
+                (select min_longitude from box),
+                (select min_latitude from box),
+                (select max_longitude from box),
+                (select max_latitude from box)
+            )
+    )
+select * except (rn), "{{ var(" version ") }}" as versao
+from filtrada
+where rn = 1

--- a/queries/models/br_rj_riodejaneiro_onibus_gps_zirix/sppo_aux_registros_filtrada_zirix.sql
+++ b/queries/models/br_rj_riodejaneiro_onibus_gps_zirix/sppo_aux_registros_filtrada_zirix.sql
@@ -64,6 +64,6 @@ with
                 (select max_latitude from box)
             )
     )
-select * except (rn), "{{ var(" version ") }}" as versao
+select * except (rn), "{{ var('version') }}" as versao
 from filtrada
 where rn = 1

--- a/queries/models/br_rj_riodejaneiro_veiculos/CHANGELOG.md
+++ b/queries/models/br_rj_riodejaneiro_veiculos/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.0.6] - 2025-02-21
 
 ### Alterado
-- Torna filtro de partição obrigatório nos modelos `gps_brt.sql` e `gps_sppo.sql`
+- Torna filtro de partição obrigatório nos modelos `gps_brt.sql` e `gps_sppo.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/448)
 
 ## [1.0.5] - 2024-11-13
 

--- a/queries/models/br_rj_riodejaneiro_veiculos/CHANGELOG.md
+++ b/queries/models/br_rj_riodejaneiro_veiculos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - br_rj_riodejaneiro_veiculos
 
+## [1.0.6] - 2025-02-21
+
+### Alterado
+- Torna filtro de partição obrigatório nos modelos `gps_brt.sql` e `gps_sppo.sql`
 
 ## [1.0.5] - 2024-11-13
 

--- a/queries/models/br_rj_riodejaneiro_veiculos/gps_brt.sql
+++ b/queries/models/br_rj_riodejaneiro_veiculos/gps_brt.sql
@@ -1,12 +1,9 @@
 {{
     config(
-        materialized='incremental',
-        partition_by={
-            'field': 'data',
-            'data_type': 'date',
-            'granularity': 'day'
-        },
-        tags=['geolocalizacao']
+        materialized="incremental",
+        partition_by={"field": "data", "data_type": "date", "granularity": "day"},
+        tags=["geolocalizacao"],
+        require_partition_filter=true,
     )
 }}
 /*
@@ -23,51 +20,54 @@ do estado de movimento ('parado', 'andando')
 com o traçado da linha informada.
 5. As junções (joins) são feitas sobre o id_veículo e a timestamp_gps.
 */
-WITH
+with
     registros as (
-    -- 1. registros_filtrada
-    SELECT
-        id_veiculo,
-        timestamp_gps,
-        timestamp_captura,
-        velocidade,
-        servico,
-        latitude,
-        longitude,
-    FROM {{ ref('brt_aux_registros_filtrada') }}
-    {% if is_incremental() -%}
-    WHERE
-      data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-      AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
-      AND DATETIME_DIFF(timestamp_captura, timestamp_gps, MINUTE) BETWEEN 0 AND 1
-    {%- endif -%}
+        -- 1. registros_filtrada
+        select
+            id_veiculo,
+            timestamp_gps,
+            timestamp_captura,
+            velocidade,
+            servico,
+            latitude,
+            longitude,
+        from {{ ref("brt_aux_registros_filtrada") }}
+        {% if is_incremental() -%}
+            where
+                data between date("{{var('date_range_start')}}") and date(
+                    "{{var('date_range_end')}}"
+                )
+                and timestamp_gps > "{{var('date_range_start')}}"
+                and timestamp_gps <= "{{var('date_range_end')}}"
+                and datetime_diff(timestamp_captura, timestamp_gps, minute)
+                between 0 and 1
+        {%- endif -%}
     ),
-    velocidades AS (
-    -- 2. velocidades
-    SELECT
-        id_veiculo, timestamp_gps, servico, velocidade, distancia, flag_em_movimento
-    FROM {{ ref('brt_aux_registros_velocidade') }}
+    velocidades as (
+        -- 2. velocidades
+        select
+            id_veiculo, timestamp_gps, servico, velocidade, distancia, flag_em_movimento
+        from {{ ref("brt_aux_registros_velocidade") }}
     ),
     paradas as (
-    -- 3. paradas
-    SELECT
-        id_veiculo, timestamp_gps, servico, tipo_parada,
-    FROM {{ ref('brt_aux_registros_parada') }}
+        -- 3. paradas
+        select id_veiculo, timestamp_gps, servico, tipo_parada,
+        from {{ ref("brt_aux_registros_parada") }}
     ),
-    flags AS (
-    -- 4. flag_trajeto_correto
-    SELECT
-        id_veiculo,
-        timestamp_gps,
-        servico,
-        route_id,
-        flag_linha_existe_sigmob,
-        flag_trajeto_correto,
-        flag_trajeto_correto_hist
-    FROM {{ ref('brt_aux_registros_flag_trajeto_correto') }}
+    flags as (
+        -- 4. flag_trajeto_correto
+        select
+            id_veiculo,
+            timestamp_gps,
+            servico,
+            route_id,
+            flag_linha_existe_sigmob,
+            flag_trajeto_correto,
+            flag_trajeto_correto_hist
+        from {{ ref("brt_aux_registros_flag_trajeto_correto") }}
     )
 -- 5. Junção final
-SELECT
+select
     "BRT" modo,
     r.timestamp_gps,
     date(r.timestamp_gps) data,
@@ -76,65 +76,63 @@ SELECT
     replace(r.servico, " ", "") as servico,
     r.latitude,
     r.longitude,
-    CASE
-        WHEN
-        flag_em_movimento IS true AND flag_trajeto_correto_hist is true
-        THEN true
-    ELSE false
-    END flag_em_operacao,
+    case
+        when flag_em_movimento is true and flag_trajeto_correto_hist is true
+        then true
+        else false
+    end flag_em_operacao,
     v.flag_em_movimento,
     p.tipo_parada,
     flag_linha_existe_sigmob,
     flag_trajeto_correto,
     flag_trajeto_correto_hist,
-    CASE
-        WHEN flag_em_movimento IS true AND flag_trajeto_correto_hist is true
-        THEN 'Em operação'
-        WHEN flag_em_movimento is true and flag_trajeto_correto_hist is false
-        THEN 'Operando fora trajeto'
-        WHEN flag_em_movimento is false
-        THEN
-            CASE
-                WHEN tipo_parada is not null
-                THEN concat("Parado ", tipo_parada)
-            ELSE
-                CASE
-                    WHEN flag_trajeto_correto_hist is true
-                    THEN 'Parado trajeto correto'
-                ELSE 'Parado fora trajeto'
-                END
-            END
-    END status,
+    case
+        when flag_em_movimento is true and flag_trajeto_correto_hist is true
+        then 'Em operação'
+        when flag_em_movimento is true and flag_trajeto_correto_hist is false
+        then 'Operando fora trajeto'
+        when flag_em_movimento is false
+        then
+            case
+                when tipo_parada is not null
+                then concat("Parado ", tipo_parada)
+                else
+                    case
+                        when flag_trajeto_correto_hist is true
+                        then 'Parado trajeto correto'
+                        else 'Parado fora trajeto'
+                    end
+            end
+    end status,
     r.velocidade velocidade_instantanea,
     v.velocidade velocidade_estimada_10_min,
     v.distancia,
-    "{{ var("version") }}" as versao
-FROM
-    registros r
+    "{{ var(" version ") }}" as versao
+from registros r
 
-JOIN
+join
     flags f
-ON
-    r.id_veiculo = f.id_veiculo
-    AND r.timestamp_gps = f.timestamp_gps
-    AND r.servico = f.servico
+    on r.id_veiculo = f.id_veiculo
+    and r.timestamp_gps = f.timestamp_gps
+    and r.servico = f.servico
 
-JOIN
+join
     velocidades v
-ON
-    r.id_veiculo = v.id_veiculo
-    AND  r.timestamp_gps = v.timestamp_gps
-    AND  r.servico = v.servico
+    on r.id_veiculo = v.id_veiculo
+    and r.timestamp_gps = v.timestamp_gps
+    and r.servico = v.servico
 
-JOIN
+join
     paradas p
-ON
-    r.id_veiculo = p.id_veiculo
-    AND  r.timestamp_gps = p.timestamp_gps
-    AND r.servico = p.servico
+    on r.id_veiculo = p.id_veiculo
+    and r.timestamp_gps = p.timestamp_gps
+    and r.servico = p.servico
 {% if is_incremental() -%}
-  WHERE
-  date(r.timestamp_gps) between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-  AND r.timestamp_gps > "{{var('date_range_start')}}" and r.timestamp_gps <="{{var('date_range_end')}}"
-  AND DATETIME_DIFF(r.timestamp_captura, r.timestamp_gps, MINUTE) BETWEEN 0 AND 1
+    where
+        date(r.timestamp_gps) between date("{{var('date_range_start')}}") and date(
+            "{{var('date_range_end')}}"
+        )
+        and r.timestamp_gps > "{{var('date_range_start')}}"
+        and r.timestamp_gps <= "{{var('date_range_end')}}"
+        and datetime_diff(r.timestamp_captura, r.timestamp_gps, minute) between 0 and 1
 {%- endif -%}

--- a/queries/models/br_rj_riodejaneiro_veiculos/gps_brt.sql
+++ b/queries/models/br_rj_riodejaneiro_veiculos/gps_brt.sql
@@ -107,7 +107,7 @@ select
     r.velocidade velocidade_instantanea,
     v.velocidade velocidade_estimada_10_min,
     v.distancia,
-    "{{ var(" version ") }}" as versao
+    "{{ var('version') }}" as versao
 from registros r
 
 join

--- a/queries/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
+++ b/queries/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
@@ -1,13 +1,10 @@
 {{
-  config(
-    materialized='incremental',
-    partition_by={
-      'field':"data",
-      'data_type':'date',
-      'granularity': 'day'
-    },
-    tags=['geolocalizacao']
-  )
+    config(
+        materialized="incremental",
+        partition_by={"field": "data", "data_type": "date", "granularity": "day"},
+        tags=["geolocalizacao"],
+        require_partition_filter=true,
+    )
 }}
 /*
 Descrição:
@@ -23,118 +20,116 @@ do estado de movimento ('parado', 'andando')
 com o traçado da linha informada.
 5. As junções (joins) são feitas sobre o id_veículo e a timestamp_gps.
 */
-WITH
-  registros as (
-  -- 1. registros_filtrada
-    SELECT
-      id_veiculo,
-      timestamp_gps,
-      timestamp_captura,
-      velocidade,
-      linha,
-      latitude,
-      longitude,
-    FROM {{ ref('sppo_aux_registros_filtrada') }}
-    {% if is_incremental() -%}
-    WHERE
-      data between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-      AND timestamp_gps > "{{var('date_range_start')}}" and timestamp_gps <="{{var('date_range_end')}}"
-    {%- endif -%}
-  ),
-  velocidades AS (
-    -- 2. velocidades
-    SELECT
-      id_veiculo, timestamp_gps, linha, velocidade, distancia, flag_em_movimento
-    FROM
-      {{ ref('sppo_aux_registros_velocidade') }}
-  ),
-  paradas as (
-    -- 3. paradas
-    SELECT
-      id_veiculo, timestamp_gps, linha, tipo_parada,
-    FROM {{ ref('sppo_aux_registros_parada') }}
-  ),
-  flags AS (
-    -- 4. flag_trajeto_correto
-    SELECT
-      id_veiculo,
-      timestamp_gps,
-      linha,
-      route_id,
-      flag_linha_existe_sigmob,
-      flag_trajeto_correto,
-      flag_trajeto_correto_hist
-    FROM
-      {{ ref('sppo_aux_registros_flag_trajeto_correto') }}
-  )
+with
+    registros as (
+        -- 1. registros_filtrada
+        select
+            id_veiculo,
+            timestamp_gps,
+            timestamp_captura,
+            velocidade,
+            linha,
+            latitude,
+            longitude,
+        from {{ ref("sppo_aux_registros_filtrada") }}
+        {% if is_incremental() -%}
+            where
+                data between date("{{var('date_range_start')}}") and date(
+                    "{{var('date_range_end')}}"
+                )
+                and timestamp_gps > "{{var('date_range_start')}}"
+                and timestamp_gps <= "{{var('date_range_end')}}"
+        {%- endif -%}
+    ),
+    velocidades as (
+        -- 2. velocidades
+        select
+            id_veiculo, timestamp_gps, linha, velocidade, distancia, flag_em_movimento
+        from {{ ref("sppo_aux_registros_velocidade") }}
+    ),
+    paradas as (
+        -- 3. paradas
+        select id_veiculo, timestamp_gps, linha, tipo_parada,
+        from {{ ref("sppo_aux_registros_parada") }}
+    ),
+    flags as (
+        -- 4. flag_trajeto_correto
+        select
+            id_veiculo,
+            timestamp_gps,
+            linha,
+            route_id,
+            flag_linha_existe_sigmob,
+            flag_trajeto_correto,
+            flag_trajeto_correto_hist
+        from {{ ref("sppo_aux_registros_flag_trajeto_correto") }}
+    )
 -- 5. Junção final
-SELECT
-  "SPPO" modo,
-  r.timestamp_gps,
-  date(r.timestamp_gps) data,
-  extract(time from r.timestamp_gps) hora,
-  r.id_veiculo,
-  r.linha as servico,
-  r.latitude,
-  r.longitude,
-  CASE
-    WHEN
-      flag_em_movimento IS true AND flag_trajeto_correto_hist is true
-      THEN true
-  ELSE false
-  END flag_em_operacao,
-  v.flag_em_movimento,
-  p.tipo_parada,
-  flag_linha_existe_sigmob,
-  flag_trajeto_correto,
-  flag_trajeto_correto_hist,
-  CASE
-    WHEN flag_em_movimento IS true AND flag_trajeto_correto_hist is true
-    THEN 'Em operação'
-    WHEN flag_em_movimento is true and flag_trajeto_correto_hist is false
-    THEN 'Operando fora trajeto'
-    WHEN flag_em_movimento is false
-    THEN
-        CASE
-            WHEN tipo_parada is not null
-            THEN concat("Parado ", tipo_parada)
-        ELSE
-            CASE
-                WHEN flag_trajeto_correto_hist is true
-                THEN 'Parado trajeto correto'
-            ELSE 'Parado fora trajeto'
-            END
-        END
-    END status,
-  r.velocidade velocidade_instantanea,
-  v.velocidade velocidade_estimada_10_min,
-  v.distancia,
-  "{{ var("version") }}" as versao
-FROM
-  registros r
+select
+    "SPPO" modo,
+    r.timestamp_gps,
+    date(r.timestamp_gps) data,
+    extract(time from r.timestamp_gps) hora,
+    r.id_veiculo,
+    r.linha as servico,
+    r.latitude,
+    r.longitude,
+    case
+        when flag_em_movimento is true and flag_trajeto_correto_hist is true
+        then true
+        else false
+    end flag_em_operacao,
+    v.flag_em_movimento,
+    p.tipo_parada,
+    flag_linha_existe_sigmob,
+    flag_trajeto_correto,
+    flag_trajeto_correto_hist,
+    case
+        when flag_em_movimento is true and flag_trajeto_correto_hist is true
+        then 'Em operação'
+        when flag_em_movimento is true and flag_trajeto_correto_hist is false
+        then 'Operando fora trajeto'
+        when flag_em_movimento is false
+        then
+            case
+                when tipo_parada is not null
+                then concat("Parado ", tipo_parada)
+                else
+                    case
+                        when flag_trajeto_correto_hist is true
+                        then 'Parado trajeto correto'
+                        else 'Parado fora trajeto'
+                    end
+            end
+    end status,
+    r.velocidade velocidade_instantanea,
+    v.velocidade velocidade_estimada_10_min,
+    v.distancia,
+    "{{ var(" version ") }}" as versao
+from registros r
 
-JOIN
-  flags f
-ON
-  r.id_veiculo = f.id_veiculo
-  AND r.timestamp_gps = f.timestamp_gps
-  AND r.linha = f.linha
+join
+    flags f
+    on r.id_veiculo = f.id_veiculo
+    and r.timestamp_gps = f.timestamp_gps
+    and r.linha = f.linha
 
-JOIN
-  velocidades v
-ON
-  r.id_veiculo = v.id_veiculo
-  AND  r.timestamp_gps = v.timestamp_gps
-  AND  r.linha = v.linha
+join
+    velocidades v
+    on r.id_veiculo = v.id_veiculo
+    and r.timestamp_gps = v.timestamp_gps
+    and r.linha = v.linha
 
-JOIN
-  paradas p
-ON
-  r.id_veiculo = p.id_veiculo
-  AND  r.timestamp_gps = p.timestamp_gps
-  AND r.linha = p.linha
+join
+    paradas p
+    on r.id_veiculo = p.id_veiculo
+    and r.timestamp_gps = p.timestamp_gps
+    and r.linha = p.linha
 {% if is_incremental() -%}
-  WHERE
-  date(r.timestamp_gps) between DATE("{{var('date_range_start')}}") and DATE("{{var('date_range_end')}}")
-  AND r.timestamp_gps > "{{var('date_range_start')}}" and r.timestamp_gps <="{{var('date_range_end')}}"
+    where
+        date(r.timestamp_gps) between date("{{var('date_range_start')}}") and date(
+            "{{var('date_range_end')}}"
+        )
+        and r.timestamp_gps > "{{var('date_range_start')}}"
+        and r.timestamp_gps <= "{{var('date_range_end')}}"
 {%- endif -%}

--- a/queries/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
+++ b/queries/models/br_rj_riodejaneiro_veiculos/gps_sppo.sql
@@ -105,7 +105,7 @@ select
     r.velocidade velocidade_instantanea,
     v.velocidade velocidade_estimada_10_min,
     v.distancia,
-    "{{ var(" version ") }}" as versao
+    "{{ var('version') }}" as versao
 from registros r
 
 join

--- a/queries/models/monitoramento/CHANGELOG.md
+++ b/queries/models/monitoramento/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - monitoramento
 
+## [1.3.2] - 2025-02-21
+
+### Alterado
+- Torna filtro de partição obrigatório no modelo `gps_viagem.sql`
+
 ## [1.3.1] - 2025-02-03
 
 ### Corrigido

--- a/queries/models/monitoramento/CHANGELOG.md
+++ b/queries/models/monitoramento/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.3.2] - 2025-02-21
 
 ### Alterado
-- Torna filtro de partição obrigatório no modelo `gps_viagem.sql`
+- Torna filtro de partição obrigatório no modelo `gps_viagem.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/448)
 
 ## [1.3.1] - 2025-02-03
 

--- a/queries/models/monitoramento/staging/gps_viagem.sql
+++ b/queries/models/monitoramento/staging/gps_viagem.sql
@@ -7,6 +7,7 @@
             "granularity": "day",
         },
         incremental_strategy="insert_overwrite",
+        require_partition_filter=true,
     )
 }}
 

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - projeto_subsidio_sppo
 
+## [9.1.8] - 2025-02-21
+
+### Alterado
+- Torna filtro de partição obrigatório no modelo `registros_status_viagem.sql`
+
 ## [9.1.7] - 2025-02-05
 
 ### Adicionado

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [9.1.8] - 2025-02-21
 
 ### Alterado
-- Torna filtro de partição obrigatório no modelo `registros_status_viagem.sql`
+- Torna filtro de partição obrigatório no modelo `registros_status_viagem.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/448)
 
 ## [9.1.7] - 2025-02-05
 

--- a/queries/models/projeto_subsidio_sppo/registros_status_viagem.sql
+++ b/queries/models/projeto_subsidio_sppo/registros_status_viagem.sql
@@ -1,48 +1,41 @@
-{{ config(
-       materialized='incremental',
-       partition_by={
-              "field":"data",
-              "data_type": "date",
-              "granularity":"day"
-       },
-       unique_key=['timestamp_gps', 'id_veiculo'],
-       incremental_strategy='insert_overwrite'
-)
+{{
+    config(
+        materialized="incremental",
+        partition_by={"field": "data", "data_type": "date", "granularity": "day"},
+        unique_key=["timestamp_gps", "id_veiculo"],
+        incremental_strategy="insert_overwrite",
+        require_partition_filter=true,
+    )
 }}
 
 -- 1. Identifica registros pertencentes a viagens
-with registros_viagem as (
-    select
-    s.* except(versao_modelo),
-    datetime_partida,
-    datetime_chegada,
-    distancia_inicio_fim,
-    id_viagem
-    from
-        {{ ref("aux_registros_status_trajeto") }} s
-    left join (
-    select
-        id_veiculo,
-        trip_id,
-        servico_realizado,
-        sentido_shape,
-        id_viagem,
-        datetime_partida,
-        datetime_chegada,
-        distancia_inicio_fim
-    from
-        {{ ref("aux_viagem_circular") }}
-    ) v
-    on
-    s.id_veiculo = v.id_veiculo
-    and s.trip_id = v.trip_id
-    and s.timestamp_gps between v.datetime_partida and v.datetime_chegada
-)
+with
+    registros_viagem as (
+        select
+            s.* except (versao_modelo),
+            datetime_partida,
+            datetime_chegada,
+            distancia_inicio_fim,
+            id_viagem
+        from {{ ref("aux_registros_status_trajeto") }} s
+        left join
+            (
+                select
+                    id_veiculo,
+                    trip_id,
+                    servico_realizado,
+                    sentido_shape,
+                    id_viagem,
+                    datetime_partida,
+                    datetime_chegada,
+                    distancia_inicio_fim
+                from {{ ref("aux_viagem_circular") }}
+            ) v
+            on s.id_veiculo = v.id_veiculo
+            and s.trip_id = v.trip_id
+            and s.timestamp_gps between v.datetime_partida and v.datetime_chegada
+    )
 -- 2. Filtra apenas registros de viagens identificadas
-select
-    *,
-    '{{ var("version") }}' as versao_modelo
-from
-    registros_viagem
-where
-    id_viagem is not null
+select *, '{{ var("version") }}' as versao_modelo
+from registros_viagem
+where id_viagem is not null


### PR DESCRIPTION
# Changelog - brt_gps

## [1.0.1] - 2025-02-21

### Alterado
- Torna filtro de partição obrigatório no modelo `brt_aux_registros_filtrada.sql`

# Changelog - br_rj_riodejaneiro_onibus_gps

## [1.0.3] - 2025-02-21

### Alterado
- Torna filtro de partição obrigatório no modelo `sppo_aux_registros_filtrada.sql`

# Changelog - onibus_gps_zirix

## [1.0.5] - 2025-02-21

### Alterado
- Torna filtro de partição obrigatório nos modelos `sppo_aux_registros_filtrada_zirix.sql` e `gps_sppo_zirix.sql`

# Changelog - br_rj_riodejaneiro_veiculos

## [1.0.6] - 2025-02-21

### Alterado
- Torna filtro de partição obrigatório nos modelos `gps_brt.sql` e `gps_sppo.sql`

# Changelog - monitoramento

## [1.3.2] - 2025-02-21

### Alterado
- Torna filtro de partição obrigatório no modelo `gps_viagem.sql`

# Changelog - projeto_subsidio_sppo

## [9.1.8] - 2025-02-21

### Alterado
- Torna filtro de partição obrigatório no modelo `registros_status_viagem.sql`