### PR TITLE
Corrige dados modificados indevidamente da coluna `tipo_veiculo`

### DIFF
--- a/pipelines/migration/veiculo/flows.py
+++ b/pipelines/migration/veiculo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for veiculos
 
-DBT: 2025-02-11
+DBT: 2025-02-24
 """
 
 from copy import deepcopy

--- a/queries/models/veiculo/CHANGELOG.md
+++ b/queries/models/veiculo/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [2.0.4] - 2025-02-24
 
 ### Alterado
-- Alterado o modelo `licenciamento.sql` para corrigir os dados modificados indevidamente da coluna `tipo_veiculo` conforme Processo.Rio MTR-CAP-2025/01125 (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/457)
+- Alterado o modelo `licenciamento.sql` para corrigir os dados modificados da coluna `tipo_veiculo` conforme Processo.Rio MTR-CAP-2025/01125 (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/457)
 
 ## [2.0.3] - 2025-02-06
 

--- a/queries/models/veiculo/CHANGELOG.md
+++ b/queries/models/veiculo/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [2.0.4] - 2025-02-24
 
 ### Alterado
-- Alterado o modelo `licenciamento.sql` para corrigir os dados modificados indevidamente da coluna `tipo_veiculos` conforme processo.rio Processo.Rio MTR-DES-2025/09057 (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/457)
+- Alterado o modelo `licenciamento.sql` para corrigir os dados modificados indevidamente da coluna `tipo_veiculo` conforme Processo.Rio MTR-CAP-2025/01125 (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/457)
 
 ## [2.0.3] - 2025-02-06
 

--- a/queries/models/veiculo/CHANGELOG.md
+++ b/queries/models/veiculo/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [2.0.4] - 2025-02-24
 
 ### Alterado
-- Alterado o modelo `licenciamento.sql` para corrigir os dados modificados indevidamente da coluna `tipo_veiculos` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+- Alterado o modelo `licenciamento.sql` para corrigir os dados modificados indevidamente da coluna `tipo_veiculos` conforme processo.rio Processo.Rio MTR-DES-2025/09057 (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/457)
 
 ## [2.0.3] - 2025-02-06
 

--- a/queries/models/veiculo/CHANGELOG.md
+++ b/queries/models/veiculo/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog - veiculo
 
-## [1.1.3] - 2025-02-06
+## [2.0.4] - 2025-02-24
+
+### Alterado
+- Alterado o modelo `licenciamento.sql` para corrigir os dados modificados indevidamente da coluna `tipo_veiculos` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+
+## [2.0.3] - 2025-02-06
 
 ### Adicionado
 - Adicionados testes no modelo `infracao.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/401)

--- a/queries/models/veiculo/licenciamento.sql
+++ b/queries/models/veiculo/licenciamento.sql
@@ -20,8 +20,7 @@ with
             where date(data) = date("{{ licenciamento_date }}")
         {% endif %}
     ),
-    -- Processo.Rio MTR-CAP-2025/01125 [Correção da alteração indevida do tipo de
-    -- veículo]
+    -- Processo.Rio MTR-CAP-2025/01125 [Correção da alteração do tipo de veículo]
     stu_tipo_veiculo as (
         select
             * except (tipo_veiculo),

--- a/queries/models/veiculo/licenciamento.sql
+++ b/queries/models/veiculo/licenciamento.sql
@@ -14,7 +14,59 @@
 
 with
     stu as (
-        select * except (data), date(data) as data
+        select
+            * except (data, tipo_veiculo),
+            date(data) as data,
+            case
+                when
+                    id_veiculo in (
+                        "B27131",
+                        "B27009",
+                        "B27013",
+                        "B27014",
+                        "B27019",
+                        "B27020",
+                        "B27005",
+                        "B27075",
+                        "B27087",
+                        "B27085",
+                        "B27084",
+                        "B27025",
+                        "B27074",
+                        "B27070",
+                        "B27076",
+                        "B27026",
+                        "D13132",
+                        "D13128",
+                        "D13127",
+                        "D13126",
+                        "D13124",
+                        "C47600",
+                        "C47577",
+                        "C47584",
+                        "C47530",
+                        "C47543",
+                        "C47545",
+                        "B31101",
+                        "B31103",
+                        "B31102",
+                        "B31054",
+                        "B31055",
+                        "B31057",
+                        "B31058",
+                        "B31066",
+                        "B31100",
+                        "B31051",
+                        "B31099",
+                        "B31094",
+                        "B31050"
+                    )
+                    and date(data) between date(
+                        "{{ var('licenciamento_tipo_veiculo_inicio') }}"
+                    ) and date("{{ var('licenciamento_tipo_veiculo_fim') }}")
+                then "51 ONIBUS BS URB C/AR C/E 2CAT"
+                else tipo_veiculo
+            end as tipo_veiculo
         from {{ ref("licenciamento_stu_staging") }} as t
         {% if is_incremental() %}
             where date(data) = date("{{ licenciamento_date }}")

--- a/queries/models/veiculo/licenciamento.sql
+++ b/queries/models/veiculo/licenciamento.sql
@@ -14,17 +14,18 @@
 
 with
     stu as (
-        select
-            * except (data),date(data) as data,
+        select * except (data), date(data) as data
         from {{ ref("licenciamento_stu_staging") }} as t
         {% if is_incremental() %}
             where date(data) = date("{{ licenciamento_date }}")
         {% endif %}
     ),
-    -- Processo.Rio MTR-DES-2025/09057
+    -- Processo.Rio MTR-CAP-2025/01125 [Correção da alteração indevida do tipo de
+    -- veículo]
     stu_tipo_veiculo as (
-        select * except(tipo_veiculo),
-        case
+        select
+            * except (tipo_veiculo),
+            case
                 when
                     id_veiculo in (
                         "B27131",
@@ -68,13 +69,15 @@ with
                         "B31094",
                         "B31050"
                     )
-                    and date(data) between date(
-                        "2025-02-01"
-                    ) and date("2025-02-17")
+                    and data
+                    between date_add("2025-02-01", interval 5 day) and date_add(
+                        "2025-02-14", interval 5 day
+                    )
+                    and tipo_veiculo = "61 RODOV. C/AR E ELEV"
                 then "51 ONIBUS BS URB C/AR C/E 2CAT"
                 else tipo_veiculo
             end as tipo_veiculo
-            from stu
+        from stu
     ),
     stu_rn as (
         select


### PR DESCRIPTION
# Changelog - veiculo

## [2.0.4] - 2025-02-24

### Alterado
- Alterado o modelo `licenciamento.sql` para corrigir os dados modificados da coluna `tipo_veiculo` conforme Processo.Rio MTR-CAP-2025/01125