### PR TITLE
Corrige os valores as colunas `valor_subsidio_pago` e `valor_penalidade` antes da apuração por faixa no modelo `monitoramento_servico_dia.sql`

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT: 2025-02-24a
+DBT: 2025-02-27
 """
 
 from prefect import Parameter, case, task

--- a/queries/models/monitoramento/CHANGELOG.md
+++ b/queries/models/monitoramento/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.3.4] - 2025-02-27
 
 ### Corrigido
-- Corrige os valores as colunas `valor_subsidio_pago` e `valor_penalidade` antes da apuração por faixa no modelo `monitoramento_servico_dia.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+- Corrige os valores as colunas `valor_subsidio_pago` e `valor_penalidade` antes da apuração por faixa no modelo `monitoramento_servico_dia.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/465)
 
 ## [1.3.2] - 2025-02-21
 

--- a/queries/models/monitoramento/CHANGELOG.md
+++ b/queries/models/monitoramento/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - monitoramento
 
+## [1.3.4] - 2025-02-27
+
+### Corrigido
+- Corrige os valores as colunas `valor_subsidio_pago` e `valor_penalidade` antes da apuração por faixa no modelo `monitoramento_servico_dia.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+
 ## [1.3.2] - 2025-02-21
 
 ### Alterado

--- a/queries/models/monitoramento/staging/monitoramento_servico_dia.sql
+++ b/queries/models/monitoramento/staging/monitoramento_servico_dia.sql
@@ -15,7 +15,7 @@ select
 from {{ ref("sumario_servico_dia_historico") }}
     -- `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
 where
-    data < date("{{ var('data_subsidio_v9_inicio') }}")  -- noqa
+    data < date("{{ var('DATA_SUBSIDIO_V9_INICIO') }}")  -- noqa
     {% if is_incremental() %}
         and data between date("{{ var('start_date') }}") and date_add(
             date("{{ var('end_date') }}"), interval 1 day

--- a/queries/models/monitoramento/staging/monitoramento_servico_dia.sql
+++ b/queries/models/monitoramento/staging/monitoramento_servico_dia.sql
@@ -10,13 +10,14 @@ select
     km_apurada,
     km_planejada,
     perc_km_planejada,
-    valor_subsidio_pago,
-    valor_penalidade
+    valor_subsidio_pago + coalesce(valor_penalidade, 0) as valor_subsidio_pago,
+    coalesce(valor_penalidade, 0) as valor_penalidade
 from {{ ref("sumario_servico_dia_historico") }}
--- `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
+    -- `rj-smtr.dashboard_subsidio_sppo.sumario_servico_dia_historico`
 where
-    data < DATE("{{ var("DATA_SUBSIDIO_V9_INICIO") }}") --noqa
+    data < date("{{ var('data_subsidio_v9_inicio') }}")  -- noqa
     {% if is_incremental() %}
-        AND data BETWEEN DATE("{{ var("start_date") }}")
-        AND DATE_ADD(DATE("{{ var("end_date") }}"), INTERVAL 1 DAY)
+        and data between date("{{ var('start_date') }}") and date_add(
+            date("{{ var('end_date') }}"), interval 1 day
+        )
     {% endif %}


### PR DESCRIPTION
# Changelog - monitoramento

## [1.3.4] - 2025-02-27

### Corrigido
- Corrige os valores as colunas `valor_subsidio_pago` e `valor_penalidade` antes da apuração por faixa no modelo `monitoramento_servico_dia.sql`