### PR TITLE
Adiciona ordenação de viagens por datetime_partida

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT: 2025-03-07
+DBT: 2025-03-10
 """
 
 from prefect import Parameter, case, task

--- a/queries/models/dashboard_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/dashboard_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - dashboard_subsidio_sppo
 
+## [7.1.2] - 2025-03-10
+
+### Adicionado
+
+- Adiciona ordenação de viagens por datetime_partida no modelo `viagens_remuneradas.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+
 ## [7.1.1] - 2025-02-21
 
 ### Alterado

--- a/queries/models/dashboard_subsidio_sppo/viagens_remuneradas.sql
+++ b/queries/models/dashboard_subsidio_sppo/viagens_remuneradas.sql
@@ -388,7 +388,7 @@ from
             p.* except (data, servico),
             row_number() over (
                 partition by v.data, v.servico, faixa_horaria_inicio, faixa_horaria_fim
-                order by subsidio_km * distancia_planejada desc
+                order by subsidio_km * distancia_planejada desc, datetime_partida asc
             ) as rn
         from viagem_km_tipo as v
         left join


### PR DESCRIPTION
# Changelog - dashboard_subsidio_sppo

## [7.1.2] - 2025-03-10

### Adicionado

- Adiciona ordenação de viagens por datetime_partida no modelo `viagens_remuneradas.sql`