### PR TITLE
Backup Jaé BillingPay - Desativa schedule do flow `backup_billingpay_historico` / Adiciona tabelas no exclude

### DIFF
--- a/pipelines/capture/jae/CHANGELOG.md
+++ b/pipelines/capture/jae/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Desativa schedule do flow `backup_billingpay_historico`
+- Desativa schedule do flow `backup_billingpay_historico` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/482)
 
 ## [1.3.1] - 2025-03-10
 

--- a/pipelines/capture/jae/CHANGELOG.md
+++ b/pipelines/capture/jae/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - source_jae
 
+## [1.3.2] - 2025-03-17
+
+### Alterado
+
+- Desativa schedule do flow `backup_billingpay_historico`
+
 ## [1.3.1] - 2025-03-10
 
 ### Alterado

--- a/pipelines/capture/jae/constants.py
+++ b/pipelines/capture/jae/constants.py
@@ -158,6 +158,7 @@ class constants(Enum):  # pylint: disable=c0103
                 "acerto_pedido_2",
                 "routes",
                 "fare_rules",
+                "estudante_12032025",
             ],
             "filter": {
                 "ITEM_PEDIDO": ["DT_INCLUSAO"],
@@ -239,6 +240,8 @@ class constants(Enum):  # pylint: disable=c0103
                 "transacao_riocard",
                 "embossadora_producao_20240809",
                 "transacao_faltante_23082023",
+                # sem permissão #
+                "temp_estudante_cpfduplicado_13032025",
             ],
             "filter": {
                 "confirmacao_envio_pms": ["data_confirmacao"],
@@ -307,6 +310,7 @@ class constants(Enum):  # pylint: disable=c0103
                 "estudante_sme_2025",
                 "estudante_universitario",
                 "estudante_sme_2025_2102",
+                "temp_estudante_cpfduplicado_13032025",
             ],
             "filter": {
                 "lancamento_conta_gratuidade": ["data_inclusao"],
@@ -426,6 +430,7 @@ class constants(Enum):  # pylint: disable=c0103
                 "jall_midia_erro",
                 "jall_midia_nao_recebida",
                 "erros_504_criacao_dock",
+                "temp_estudante_cpfduplicado_13032025",
             ],
             "filter": {
                 "midia_evento": ["dt_inclusao"],

--- a/pipelines/capture/jae/flows.py
+++ b/pipelines/capture/jae/flows.py
@@ -202,19 +202,19 @@ backup_billingpay_historico.state_handlers = [
     handler_initialize_sentry,
 ]
 
-backup_billingpay_historico.schedule = Schedule(
-    [
-        IntervalClock(
-            interval=timedelta(minutes=30),
-            start_date=datetime(
-                2021, 1, 1, 0, 0, 0, tzinfo=timezone(smtr_constants.TIMEZONE.value)
-            ),
-            labels=[
-                smtr_constants.RJ_SMTR_AGENT_LABEL.value,
-            ],
-            parameter_defaults={"database_name": db, "table_id": t},
-        )
-        for db, v in constants.BACKUP_JAE_BILLING_PAY_HISTORIC.value.items()
-        for t in v.keys()
-    ]
-)
+# backup_billingpay_historico.schedule = Schedule(
+#     [
+#         IntervalClock(
+#             interval=timedelta(minutes=30),
+#             start_date=datetime(
+#                 2021, 1, 1, 0, 0, 0, tzinfo=timezone(smtr_constants.TIMEZONE.value)
+#             ),
+#             labels=[
+#                 smtr_constants.RJ_SMTR_AGENT_LABEL.value,
+#             ],
+#             parameter_defaults={"database_name": db, "table_id": t},
+#         )
+#         for db, v in constants.BACKUP_JAE_BILLING_PAY_HISTORIC.value.items()
+#         for t in v.keys()
+#     ]
+# )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - Atualizado o registro de versão para 1.3.2 com a desabilitação do agendamento automático do fluxo `backup_billingpay_historico`.
  - Refinados os critérios de filtragem de dados nas operações de backup com a adição de novos constantes para exclusão.

Essas mudanças otimizam a gestão dos processos internos sem impactar a experiência do usuário.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->