### PR TITLE
Remove o valor da penalidade da coluna valor_judicial

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT: 2025-05-13b
+DBT: 2025-05-14
 """
 
 from prefect import Parameter, case, task

--- a/queries/models/dashboard_subsidio_sppo_v2/CHANGELOG.md
+++ b/queries/models/dashboard_subsidio_sppo_v2/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Alterado o calculo da coluna `valor_judicial` para não somar o `valor_penalidade` a partir e `2025-04-01` no modelo `sumario_faixa_servico_dia_pagamento.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+- Alterado o calculo da coluna `valor_judicial` para não somar o `valor_penalidade` a partir e `2025-04-01` no modelo `sumario_faixa_servico_dia_pagamento.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/580)
 
 ## [1.0.7] - 2025-05-09
 

--- a/queries/models/dashboard_subsidio_sppo_v2/CHANGELOG.md
+++ b/queries/models/dashboard_subsidio_sppo_v2/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - dashboard_subsidio_sppo_v2
 
+## [1.0.8] - 2025-05-14
+
+### Alterado
+
+- Alterado o calculo da coluna `valor_judicial` para não somar o `valor_penalidade` a partir e `2025-04-01` no modelo `sumario_faixa_servico_dia_pagamento.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+
 ## [1.0.7] - 2025-05-09
 
 ### Corrigido

--- a/queries/models/dashboard_subsidio_sppo_v2/sumario_faixa_servico_dia_pagamento.sql
+++ b/queries/models/dashboard_subsidio_sppo_v2/sumario_faixa_servico_dia_pagamento.sql
@@ -78,7 +78,7 @@ with
             ) as valor_total_sem_glosa,
             sum(valor_apurado) + p.valor_penalidade as valor_total_com_glosa,
             case
-                when p.valor_penalidade != 0
+                when p.valor_penalidade != 0 and data < date("{{ var('DATA_SUBSIDIO_V15_INICIO') }}")
                 then - p.valor_penalidade
                 else
                     safe_cast(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correções de Bug**
  - Ajustada a regra de cálculo da coluna `valor_judicial` para que, a partir de 01/04/2025, o valor de penalidade (`valor_penalidade`) não seja mais somado ao valor judicial nos relatórios de subsídio.

- **Documentação**
  - Adicionada entrada no changelog detalhando a alteração no cálculo do `valor_judicial`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->