### PR TITLE
Altera tipo_os 2025-05-24

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT 2025-05-29
+DBT 2025-06-09
 """
 
 from prefect import Parameter, case, task

--- a/pipelines/treatment/planejamento/flows.py
+++ b/pipelines/treatment/planejamento/flows.py
@@ -2,7 +2,7 @@
 """
 Flows de tratamento dos dados de planejamento
 
-DBT 2025-05-29
+DBT 2025-06-09
 """
 
 from pipelines.constants import constants as smtr_constants

--- a/queries/models/planejamento/CHANGELOG.md
+++ b/queries/models/planejamento/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Alterado o `subtipo_dia` 'Marcha para Jesus' para o dia `2025-05-24` no modelo `calendario` em razão da Operação Especial "Todo Mundo no Rio" - Lady Gaga [Processo.Rio MTR-PRO-2025/04520] (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/598)
+- Alterado o `subtipo_dia` 'Marcha para Jesus' para o dia `2025-05-24` no modelo `calendario` em razão da Operação Especial "Todo Mundo no Rio" - Lady Gaga [Processo.Rio MTR-PRO-2025/04520] (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/619)
 
 ## [1.4.5] - 2025-05-29
 

--- a/queries/models/planejamento/CHANGELOG.md
+++ b/queries/models/planejamento/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - planejamento
 
+## [1.4.6] - 2025-06-09
+
+### Alterado
+
+- Alterado o `subtipo_dia` 'Marcha para Jesus' para o dia `2025-05-24` no modelo `calendario` em razão da Operação Especial "Todo Mundo no Rio" - Lady Gaga [Processo.Rio MTR-PRO-2025/04520] (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/598)
+
 ## [1.4.5] - 2025-05-29
 
 ### Adicionado

--- a/queries/models/planejamento/calendario.sql
+++ b/queries/models/planejamento/calendario.sql
@@ -198,6 +198,10 @@ select
             data between date(2025, 05, 03) and date(2025, 05, 04)
             and c.tipo_os = "Dia Atípico"
         then "Lady Gaga"  -- Processo.Rio MTR-PRO-2025/04520 [Operação Especial "Todo Mundo no Rio" - Lady Gaga]
+        when
+            data = date(2025, 05, 24)
+            and c.tipo_os = "Dia Atípico"
+        then "Marcha para Jesus"  -- [Operação especial evento "Marcha para Jesus"]
         when c.tipo_os = "Regular"
         then null
         else c.tipo_os

--- a/queries/models/planejamento/calendario.sql
+++ b/queries/models/planejamento/calendario.sql
@@ -201,7 +201,7 @@ select
         when
             data = date(2025, 05, 24)
             and c.tipo_os = "Dia Atípico"
-        then "Marcha para Jesus"  -- [Operação especial evento "Marcha para Jesus"]
+        then "Marcha para Jesus"  -- Processo.Rio ... [Operação especial evento "Marcha para Jesus"]
         when c.tipo_os = "Regular"
         then null
         else c.tipo_os

--- a/queries/models/planejamento/calendario.sql
+++ b/queries/models/planejamento/calendario.sql
@@ -201,7 +201,7 @@ select
         when
             data = date(2025, 05, 24)
             and c.tipo_os = "Dia Atípico"
-        then "Marcha para Jesus"  -- Processo.Rio ... [Operação especial evento "Marcha para Jesus"]
+        then "Marcha para Jesus"  -- [processo] [Operação especial evento "Marcha para Jesus"]
         when c.tipo_os = "Regular"
         then null
         else c.tipo_os

--- a/queries/models/planejamento/staging/aux_calendario_manual.sql
+++ b/queries/models/planejamento/staging/aux_calendario_manual.sql
@@ -85,7 +85,7 @@ with
                 when data between date(2025, 05, 03) and date(2025, 05, 04)
                 then "Dia Atípico"  -- Processo.Rio MTR-PRO-2025/04520
                 when data = date(2025, 05, 24)
-                then "Dia Atípico"  -- Processo.Rio ...
+                then "Dia Atípico"  -- [processo] 
             end as tipo_os
         from
             unnest(

--- a/queries/models/planejamento/staging/aux_calendario_manual.sql
+++ b/queries/models/planejamento/staging/aux_calendario_manual.sql
@@ -85,7 +85,7 @@ with
                 when data between date(2025, 05, 03) and date(2025, 05, 04)
                 then "Dia Atípico"  -- Processo.Rio MTR-PRO-2025/04520
                 when data = date(2025, 05, 24)
-                then "Dia Atípico"  -- [processo] 
+                then "Dia Atípico"  -- [processo]
             end as tipo_os
         from
             unnest(

--- a/queries/models/planejamento/staging/aux_calendario_manual.sql
+++ b/queries/models/planejamento/staging/aux_calendario_manual.sql
@@ -85,7 +85,7 @@ with
                 when data between date(2025, 05, 03) and date(2025, 05, 04)
                 then "Dia Atípico"  -- Processo.Rio MTR-PRO-2025/04520
                 when data = date(2025, 05, 24)
-                then "Dia Atípico"  -- Processo.Rio MTR-PRO-2025/04520
+                then "Dia Atípico"  -- Processo.Rio ...
             end as tipo_os
         from
             unnest(

--- a/queries/models/planejamento/staging/aux_calendario_manual.sql
+++ b/queries/models/planejamento/staging/aux_calendario_manual.sql
@@ -84,6 +84,8 @@ with
                 then "Extraordinária - Verão"  -- Processo.Rio MTR-PRO-2025/04520
                 when data between date(2025, 05, 03) and date(2025, 05, 04)
                 then "Dia Atípico"  -- Processo.Rio MTR-PRO-2025/04520
+                when data = date(2025, 05, 24)
+                then "Dia Atípico"  -- Processo.Rio MTR-PRO-2025/04520
             end as tipo_os
         from
             unnest(

--- a/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
+++ b/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
@@ -669,7 +669,7 @@
                     when
                         data = date(2025, 05, 24)
                         and ifnull(c.tipo_os, d.tipo_os) = "Dia Atípico"
-                    then "Marcha para Jesus"  -- [Operação especial evento "Marcha para Jesus"]
+                    then "Marcha para Jesus"  -- Processo.Rio ... [Operação especial evento "Marcha para Jesus"]
                     when ifnull(c.tipo_os, d.tipo_os) = "Regular"
                     then null
                     else ifnull(c.tipo_os, d.tipo_os)

--- a/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
+++ b/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
@@ -669,7 +669,7 @@
                     when
                         data = date(2025, 05, 24)
                         and ifnull(c.tipo_os, d.tipo_os) = "Dia Atípico"
-                    then "Marcha para Jesus"  -- Processo.Rio ... [Operação especial evento "Marcha para Jesus"]
+                    then "Marcha para Jesus"  -- [processo] [Operação especial evento "Marcha para Jesus"]
                     when ifnull(c.tipo_os, d.tipo_os) = "Regular"
                     then null
                     else ifnull(c.tipo_os, d.tipo_os)

--- a/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
+++ b/queries/models/projeto_subsidio_sppo/subsidio_data_versao_efetiva.sql
@@ -666,6 +666,10 @@
                         data between date(2025, 05, 03) and date(2025, 05, 04)
                         and ifnull(c.tipo_os, d.tipo_os) = "Dia Atípico"
                     then "Lady Gaga"  -- Processo.Rio MTR-PRO-2025/04520 [Operação Especial "Todo Mundo no Rio" - Lady Gaga]
+                    when
+                        data = date(2025, 05, 24)
+                        and ifnull(c.tipo_os, d.tipo_os) = "Dia Atípico"
+                    then "Marcha para Jesus"  -- [Operação especial evento "Marcha para Jesus"]
                     when ifnull(c.tipo_os, d.tipo_os) = "Regular"
                     then null
                     else ifnull(c.tipo_os, d.tipo_os)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Novos Recursos**
    - Adicionada classificação do dia 24 de maio de 2025 como "Marcha para Jesus" em calendários e consultas relacionadas, refletindo operação especial para essa data.

- **Documentação**
    - Atualizado o changelog para a versão 1.4.6 com registro da nova classificação de data.
    - Atualizadas datas em docstrings para 2025-06-09.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->