### PR TITLE
Corrige data de inicio de testes da viagem planejada

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT: 2025-07-08
+DBT: 2025-07-10
 """
 
 from prefect import Parameter, case, task

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - projeto_subsidio_sppo
 
+## [9.2.8] - 2025-07-10
+
+### Corrigido
+
+- Corrigidos data de inicio dos testes das colunas `feed_start_date`, `id_tipo_trajeto`, `feed_version` e `partidas_total_planejada` no modelo `viagem_planejada.sql` para a partir de `2024-04-01` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/)
+
 ## [9.2.7] - 2025-07-02
 
 ### Adicionado

--- a/queries/models/projeto_subsidio_sppo/schema.yml
+++ b/queries/models/projeto_subsidio_sppo/schema.yml
@@ -49,6 +49,7 @@ models:
               to: ref('tecnologia_servico')
               field: servico
               to_condition: "inicio_vigencia <= date('{{ var('date_range_end') }}') and (fim_vigencia is null OR fim_vigencia >= date('{{ var('date_range_start') }}'))"
+              where: "data BETWEEN greatest(date('{date_range_start}'), date('{DATA_SUBSIDIO_V13_INICIO}')) and date('{date_range_end}')"
       - name: vista
         description: "Itinerário do serviço [ex: Bananal ↔ Saens Peña]"
         tests:
@@ -72,6 +73,7 @@ models:
         tests:
           - not_null:
               name: not_null__partidas_total_planejada__viagem_planejada
+              where: "data BETWEEN greatest(date('{date_range_start}'), date('{DATA_SUBSIDIO_V6_INICIO}')) and date('{date_range_end}')"
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: false
@@ -164,6 +166,7 @@ models:
         tests:
           - not_null:
               name: not_null__id_tipo_trajeto__viagem_planejada
+              where: "data BETWEEN greatest(date('{date_range_start}'), date('{DATA_SUBSIDIO_V6_INICIO}')) and date('{date_range_end}')"
           - accepted_values:
               values: [0,1]
               quote: false
@@ -173,11 +176,13 @@ models:
         tests:
           - not_null:
               name: not_null__feed_version__viagem_planejada
+              where: "data BETWEEN greatest(date('{date_range_start}'), date('{DATA_SUBSIDIO_V6_INICIO}')) and date('{date_range_end}')"
       - name: feed_start_date
         description: "Data inicial do feed do GTFS [Válida a partir de 2024-04-01]"
         tests:
           - not_null:
               name: not_null__feed_start_date__viagem_planejada
+              where: "data BETWEEN greatest(date('{date_range_start}'), date('{DATA_SUBSIDIO_V6_INICIO}')) and date('{date_range_end}')"
       - name: datetime_ultima_atualizacao
         description: "{{ doc('datetime_ultima_atualizacao') }}"
         tests:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * Adicionada uma nova entrada no changelog detalhando a correção do início do período de testes para colunas específicas no modelo `viagem_planejada`.

* **Correção de Bugs**
  * Corrigido o período de início dos testes das colunas `feed_start_date`, `id_tipo_trajeto`, `feed_version` e `partidas_total_planejada` para começar em 01/04/2024.

* **Testes**
  * Adicionados filtros condicionais nos testes do modelo `viagem_planejada`, limitando a execução conforme o intervalo de datas relevante.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->