### PR TITLE
Alterados o `tipo_dia` no modelo `aux_calendario_manual.sql` de `2025-07-04` e `2025-07-07` -> `Ponto facultativo`

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT: 2025-07-17
+DBT: 2025-07-22
 """
 
 from prefect import Parameter, case, task

--- a/pipelines/treatment/planejamento/flows.py
+++ b/pipelines/treatment/planejamento/flows.py
@@ -2,7 +2,7 @@
 """
 Flows de tratamento dos dados de planejamento
 
-DBT 2025-07-08
+DBT 2025-07-22
 """
 
 from pipelines.constants import constants as smtr_constants

--- a/queries/models/planejamento/CHANGELOG.md
+++ b/queries/models/planejamento/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Alterado
 
-- Alterados o `tipo_dia` no modelo `aux_calendario_manual.sql` de `2025-07-04` e `2025-07-07` -> `Ponto facultativo` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/671)
+- Alterados o `tipo_dia` no modelo `aux_calendario_manual.sql` de `2025-07-04` e `2025-07-07` -> `Ponto facultativo` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/718)
 
 ## [1.4.8] - 2025-07-08
 

--- a/queries/models/planejamento/CHANGELOG.md
+++ b/queries/models/planejamento/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - planejamento
 
+## [1.4.9] - 2025-07-22
+
+### Alterado
+
+- Alterados o `tipo_dia` no modelo `aux_calendario_manual.sql` de `2025-07-04` e `2025-07-07` -> `Ponto facultativo` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/671)
+
 ## [1.4.8] - 2025-07-08
 
 ### Alterado

--- a/queries/models/planejamento/staging/aux_calendario_manual.sql
+++ b/queries/models/planejamento/staging/aux_calendario_manual.sql
@@ -37,9 +37,9 @@ with
                 when data = date(2025, 06, 20)
                 then "Ponto Facultativo"  -- DECRETO RIO Nº 56189 DE 10 DE JUNHO DE 2025 / MTR-MEM-2025/01539
                 when data = date(2025, 07, 04)
-                then "Ponto Facultativo"  -- LEI Nº 8.881, DE 14 DE ABRIL DE 2025 / MTR-PRO-2025/16278 
+                then "Ponto Facultativo"  -- LEI Nº 8.881, DE 14 DE ABRIL DE 2025 / MTR-PRO-2025/16278
                 when data = date(2025, 07, 07)
-                then "Ponto Facultativo"  -- LEI Nº 8.881, DE 14 DE ABRIL DE 2025 / MTR-PRO-2025/16278 
+                then "Ponto Facultativo"  -- LEI Nº 8.881, DE 14 DE ABRIL DE 2025 / MTR-PRO-2025/16278
             end as tipo_dia,
             case
                 when data between date(2024, 09, 14) and date(2024, 09, 15)

--- a/queries/models/planejamento/staging/aux_calendario_manual.sql
+++ b/queries/models/planejamento/staging/aux_calendario_manual.sql
@@ -36,6 +36,10 @@ with
                 then "Domingo"  -- DECRETO RIO Nº 56189 DE 10 DE JUNHO DE 2025 / MTR-MEM-2025/01539
                 when data = date(2025, 06, 20)
                 then "Ponto Facultativo"  -- DECRETO RIO Nº 56189 DE 10 DE JUNHO DE 2025 / MTR-MEM-2025/01539
+                when data = date(2025, 07, 04)
+                then "Ponto Facultativo"  -- LEI Nº 8.881, DE 14 DE ABRIL DE 2025 / MTR-PRO-2025/16278 
+                when data = date(2025, 07, 07)
+                then "Ponto Facultativo"  -- LEI Nº 8.881, DE 14 DE ABRIL DE 2025 / MTR-PRO-2025/16278 
             end as tipo_dia,
             case
                 when data between date(2024, 09, 14) and date(2024, 09, 15)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * Atualização das datas nas docstrings de módulos para refletir a nova versão do DBT.
  * Inclusão de novo registro no changelog referente à versão 1.4.9, detalhando a alteração dos dias 04/07/2025 e 07/07/2025 para "Ponto facultativo".

* **Correções**
  * Atualização do calendário para considerar os dias 04/07/2025 e 07/07/2025 como "Ponto facultativo", conforme legislação vigente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->