### PR TITLE
[hotfix] Corrige data final da soma de km planejada do dia seguinte no modelo viagem_planejada

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT: 2025-07-23
+DBT: 2025-07-24
 """
 
 from prefect import Parameter, case, task

--- a/pipelines/treatment/cadastro/flows.py
+++ b/pipelines/treatment/cadastro/flows.py
@@ -2,7 +2,7 @@
 """
 Flows de tratamento dos dados de cadastro
 
-DBT: 2025-07-03
+DBT: 2025-07-24
 """
 
 from pipelines.capture.jae.constants import constants as jae_constants

--- a/pipelines/treatment/monitoramento/flows.py
+++ b/pipelines/treatment/monitoramento/flows.py
@@ -2,7 +2,7 @@
 """
 Flows de tratamento dos dados de monitoramento
 
-DBT: 2025-07-23
+DBT: 2025-07-24
 """
 
 from copy import deepcopy

--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -116,7 +116,7 @@ vars:
   tipo_materializacao: "subsidio"
   data_inicio_trips_shapes: "2023-04-01"
   data_inclusao_autuacao_disciplinar: "2025-07-10"
-  data_processamento_veiculo_licenciamento_dia: ["'2025-07-10'", "'2025-07-23'"]
+  data_processamento_veiculo_licenciamento_dia: ["'2025-07-10'", "'2025-07-24'"]
   # Feature penalidade de autuação por inoperância do ar condicionado (DECRETO RIO 51940/2023)
   DATA_SUBSIDIO_V2_INICIO: "2023-01-16"
   # Feature penalidade de autuação por segurança e limpeza/equipamento (DECRETO RIO 52820/2023)

--- a/queries/models/projeto_subsidio_sppo/CHANGELOG.md
+++ b/queries/models/projeto_subsidio_sppo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - projeto_subsidio_sppo
 
+## [9.3.2] - 2025-07-24
+
+### Corrigido
+
+- Corrigida a data final da soma de quilometragem planejada para o dia seguinte no modelo `viagem_planejada_v2.sql` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/721)
+
 ## [9.3.1] - 2025-07-23
 
 ### Corrigido

--- a/queries/models/projeto_subsidio_sppo/staging/viagem_planejada_v2.sql
+++ b/queries/models/projeto_subsidio_sppo/staging/viagem_planejada_v2.sql
@@ -69,7 +69,7 @@ with
             and feed_start_date = date("{{ feed_start_dates[1] }}")
             and tipo_dia = "{{ tipo_dias[1] }}"
     ),
-    {% if var('run_date') < var('DATA_GTFS_V4_INICIO') %}
+    {% if var('run_date') <= var('DATA_GTFS_V4_INICIO') %}
     -- 2. Busca partidas e quilometragem da faixa horaria (dia anterior)
     dia_anterior as (
         select
@@ -170,7 +170,7 @@ with
             sentido_shape,
             id_tipo_trajeto,
         from dia_atual
-        {% if var('run_date') < var('DATA_GTFS_V4_INICIO') %}
+        {% if var('run_date') <= var('DATA_GTFS_V4_INICIO') %}
         union all
         select
             feed_version,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Correções**
  * Ajustado o valor de uma data de processamento no arquivo de configuração.
  * Alterada a lógica de comparação de datas em consultas para incluir a data limite, garantindo que os dados do dia de início também sejam considerados.
  * Corrigida a data final usada para somar a quilometragem planejada do dia seguinte em modelo de dados.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->