### PR TITLE
Altera exceção para tipo de dia Tipo Enem

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT: 2025-11-25
+DBT: 2025-11-26
 
 """
 

--- a/pipelines/treatment/planejamento/flows.py
+++ b/pipelines/treatment/planejamento/flows.py
@@ -2,7 +2,7 @@
 """
 Flows de tratamento dos dados de planejamento
 
-DBT 2025-11-27
+DBT: 2025-11-27
 """
 
 from pipelines.constants import constants as smtr_constants

--- a/queries/dbt_project.yml
+++ b/queries/dbt_project.yml
@@ -160,10 +160,11 @@ vars:
   DATA_SUBSIDIO_V20_INICIO: "2025-08-16"
   # Feature RESOLUÇÃO SMTR 3878/2025
   DATA_SUBSIDIO_V21_INICIO: "2025-10-01"
+  # Suspensão da glosa por ar-condicionado a partir de 16/10/2025
+  DATA_SUBSIDIO_V22_INICIO: "2025-10-16"
   # Placeholder feature
   DATA_SUBSIDIO_V99_INICIO: "3000-01-01"
-
-  # Recursos #
+   # Recursos #
   recurso_staging: "rj-smtr-staging.projeto_subsidio_sppo_staging.recurso"
   recurso_prazo: "rj-smtr.projeto_subsidio_sppo.recurso_prazo"
   recurso_julgamento: "rj-smtr.projeto_subsidio_sppo.recurso_julgamento"

--- a/queries/models/subsidio/CHANGELOG.md
+++ b/queries/models/subsidio/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - subsidio
 
+## [2.2.6] - 2025-11-26
+
+### Alterado
+
+- Altera data do modelo `viagem_regularidade_temperatura` para interrupção das glosas por climatização (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/1069)
+
 ## [2.2.5] - 2025-11-14
 
 ### Alterado

--- a/queries/models/subsidio/viagem_regularidade_temperatura.sql
+++ b/queries/models/subsidio/viagem_regularidade_temperatura.sql
@@ -12,7 +12,7 @@
 
 {% set condicao_veiculo %}
     (vt.ano_fabricacao <= 2019 or vt.data >= date('{{ var("DATA_SUBSIDIO_V19_INICIO") }}'))
-    and not vt.indicador_temperatura_nula_viagem
+    and not vt.indicador_temperatura_nula_viagem and (vt.data < date('{{ var("DATA_SUBSIDIO_V22_INICIO") }}'))
 {% endset %}
 
 with


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Melhorias**
  * Adicionada exceção que permite incluir dados ENEM aos domingos para uma combinação específica de data e tipo de serviço, preservando comportamento anterior para os demais casos.

* **Documentação**
  * Atualizadas datas em cabeçalhos de módulos e adicionada entrada 1.2.9 ao changelog registrando a exceção.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->