### PR TITLE
[HOTFIX] Corrige end date na verificação da captura da Jaé

### DIFF
--- a/pipelines/capture/jae/utils.py
+++ b/pipelines/capture/jae/utils.py
@@ -478,9 +478,9 @@ def get_jae_timestamp_captura_count(
                 jae_start_ts_utc.replace(hour=0, minute=0, second=0, microsecond=0)
                 - timedelta(minutes=delay + 1)
             ).strftime("%Y-%m-%d %H:%M:%S"),
-            end=jae_end_ts_utc.replace(hour=23, minute=59, second=59, microsecond=59).strftime(
-                "%Y-%m-%d %H:%M:%S"
-            ),
+            end=(jae_end_ts_utc + timedelta(minutes=delay))
+            .replace(hour=23, minute=59, second=59, microsecond=59)
+            .strftime("%Y-%m-%d %H:%M:%S"),
             delay=delay,
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrigido o cálculo do limite superior da janela temporal em consultas de contagem, que agora considera atrasos antes de aplicar o limite de 23:59:59, melhorando a precisão das linhas contabilizadas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->