### PR TITLE
Retorna recaptura CAPTURA_REGISTROS_CITTATI para cada hora

### DIFF
--- a/pipelines/capture/cittati/flows.py
+++ b/pipelines/capture/cittati/flows.py
@@ -5,7 +5,7 @@ from pipelines.capture.cittati.constants import constants
 from pipelines.capture.cittati.tasks import create_gps_extractor
 from pipelines.capture.templates.flows import create_default_capture_flow
 from pipelines.constants import constants as smtr_constants
-from pipelines.schedules import create_hourly_cron, create_minute_cron
+from pipelines.schedules import create_hourly_cron
 from pipelines.utils.prefect import handler_notify_failure
 
 CAPTURA_REGISTROS_CITTATI = create_default_capture_flow(
@@ -13,8 +13,7 @@ CAPTURA_REGISTROS_CITTATI = create_default_capture_flow(
     source=constants.CITTATI_REGISTROS_SOURCE.value,
     create_extractor_task=create_gps_extractor,
     agent_label=smtr_constants.RJ_SMTR_AGENT_LABEL.value,
-    recapture_days=20,
-    recapture_schedule_cron=create_minute_cron(minute=12),
+    recapture_schedule_cron=create_hourly_cron(),
 )
 CAPTURA_REGISTROS_CITTATI.state_handlers.append(
     handler_notify_failure(webhook="alertas_gps_onibus")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas da Versão

* **Chores**
  * Ajustada a frequência de captura de dados Cittati de a cada minuto para a cada hora, otimizando o processo de sincronização de registros e realocação.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->