### PR TITLE
Adiciona exceção ao modelo `subsidio_penalidade_servico_faixa_v2`

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT 2026-04-08
+DBT 2026-04-10
 """
 
 from datetime import datetime

--- a/queries/models/financeiro_interno/CHANGELOG.md
+++ b/queries/models/financeiro_interno/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - financeiro_interno
 
+## [1.0.2] - 2026-04-10
+
+### Alterado
+
+- Adiciona exceção ao modelo `subsidio_penalidade_servico_faixa_v2` para suspensão das penalidades do percentual de operação por faixa horárias em virtude do desempenho da operação em serviços especificados no Processo SEI_000301.005390_2026_67 (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/1390)
+
 ## [1.0.1] - 2026-02-27
 
 ### Alterado

--- a/queries/models/financeiro_interno/staging/subsidio_penalidade_servico_faixa_v2.sql
+++ b/queries/models/financeiro_interno/staging/subsidio_penalidade_servico_faixa_v2.sql
@@ -65,7 +65,7 @@ select
             )
             or (s.servico in ("133", "607", "711") and s.data = "2026-03-19")
             or (s.servico in ("133", "607") and s.data = "2026-03-20")
-        then 0
+        then 0 --Processo SEI_000301.005390_2026_67
         else safe_cast(coalesce(pe.valor_penalidade, 0) as numeric)
     end as valor_penalidade,
     '{{ var("version") }}' as versao,

--- a/queries/models/financeiro_interno/staging/subsidio_penalidade_servico_faixa_v2.sql
+++ b/queries/models/financeiro_interno/staging/subsidio_penalidade_servico_faixa_v2.sql
@@ -56,9 +56,21 @@ select
     s.sentido,
     faixa_horaria_inicio,
     faixa_horaria_fim,
-    safe_cast(coalesce(pe.valor_penalidade, 0) as numeric) as valor_penalidade,
+    case
+        when
+            (
+                s.servico
+                in ("201", "202", "006", "133", "507", "426", "607", "711", "416")
+                and s.data = "2026-03-18"
+            )
+            or (s.servico in ("133", "607", "711") and s.data = "2026-03-19")
+            or (s.servico in ("133", "607") and s.data = "2026-03-20")
+        then 0
+        else safe_cast(coalesce(pe.valor_penalidade, 0) as numeric)
+    end as valor_penalidade,
     '{{ var("version") }}' as versao,
     current_datetime("America/Sao_Paulo") as datetime_ultima_atualizacao
+
 from subsidio_dia as s
 left join
     penalidade as pe


### PR DESCRIPTION
Adiciona exceção ao modelo `subsidio_penalidade_servico_faixa_v2` para suspensão das penalidades do percentual de operação por faixa horárias em virtude do desempenho da operação em serviços especificados no Processo SEI_000301.005390_2026_67 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **Bug Fixes**
  * Ajuste na lógica de cálculo do valor de penalidade: para serviços e datas específicas, as penalidades agora são suspensas; demais cenários mantêm o comportamento anterior.

* **Documentation**
  * Adicionado registro de versão 1.0.2 (2026-04-10) descrevendo a exceção aplicada às penalidades para os serviços afetados.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->