### PR TITLE
Adiciona  "Ponto Facultativo" para 02 de abril de 2026 no calendário

### DIFF
--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -3,7 +3,7 @@
 """
 Flows for projeto_subsidio_sppo
 
-DBT 2026-04-13
+DBT 2026-04-16
 """
 
 from datetime import datetime

--- a/pipelines/treatment/planejamento/flows.py
+++ b/pipelines/treatment/planejamento/flows.py
@@ -2,7 +2,7 @@
 """
 Flows de tratamento dos dados de planejamento
 
-DBT 2026-03-31
+DBT 2026-04-16
 """
 
 from pipelines.constants import constants as smtr_constants

--- a/queries/models/planejamento/CHANGELOG.md
+++ b/queries/models/planejamento/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - planejamento
 
+## [1.7.0] - 2026-04-16
+
+### Alterado
+
+- Alterado o `tipo_dia` no modelo `aux_calendario_manual.sql` de `2026-04-02` -> `Ponto Facultativo` conforme DECRETO RIO Nº 57802 DE 30 DE MARÇO DE 2026 (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/1398)
+
 ## [1.6.9] - 2026-03-31
 
 ### Alterado

--- a/queries/models/planejamento/staging/aux_calendario_manual.sql
+++ b/queries/models/planejamento/staging/aux_calendario_manual.sql
@@ -68,6 +68,8 @@ with
                 then "Domingo"  -- 000399.001590/2026-17 - Determinação de tipos dia de Carnaval
                 when data = date(2026, 02, 18)
                 then "Sabado"  -- 000399.001590/2026-17 - Determinação de tipos dia de Carnaval
+                when data = date(2026, 04, 02)
+                then "Ponto Facultativo"  -- DECRETO RIO Nº 57802 DE 30 DE MARÇO DE 2026
             end as tipo_dia,
             case
                 when data between date(2024, 09, 14) and date(2024, 09, 15)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Melhorias**
  * O calendário de planejamento foi atualizado para classificar corretamente datas específicas como ponto facultativo, em conformidade com decretos legislativos. Essa alteração garante maior precisão no agendamento, na gestão de recursos e na previsão de prazos de projetos, alinhando o sistema à legislação brasileira vigente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->