### PR TITLE
Aumenta o tempo de timeout de execução

### DIFF
--- a/pipelines/treatment/validacao_dados_jae/flows.py
+++ b/pipelines/treatment/validacao_dados_jae/flows.py
@@ -2,7 +2,7 @@
 """
 Flows de tratamento dos dados da validação dos dados da Jaé
 
-DBT 2026-04-01
+DBT 2026-04-28
 """
 
 from pipelines.constants import constants as smtr_constants

--- a/queries/profiles.yml
+++ b/queries/profiles.yml
@@ -2,7 +2,7 @@ queries:
   outputs:
     dev:
       dataset: dbt
-      job_execution_timeout_seconds: 14400
+      job_execution_timeout_seconds: 28800
       job_retries: 1
       keyfile: /tmp/credentials.json
       location: us
@@ -28,7 +28,7 @@ queries:
             spark.driver.memoryOverhead: 1g
     hmg:
       dataset: dbt
-      job_execution_timeout_seconds: 14400
+      job_execution_timeout_seconds: 28800
       job_retries: 1
       keyfile: /tmp/credentials.json
       location: us
@@ -54,7 +54,7 @@ queries:
             spark.driver.memoryOverhead: 1g
     prod:
       dataset: dbt
-      job_execution_timeout_seconds: 14400
+      job_execution_timeout_seconds: 28800
       job_retries: 1
       keyfile: /tmp/credentials.json
       location: us


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Notas da Versão

* **Chores**
  * Aumentado o tempo limite de execução de tarefas de 4 para 8 horas em ambientes de desenvolvimento, homologação e produção no BigQuery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->