### PR TITLE
Remove schedule dos flows de monitoramento_veiculo, monitoramento_temperatura e gtfs

### DIFF
--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - gtfs
 
+## [1.3.2] - 2026-04-29
+
+### Removido
+
+- Remove schedule do flow `gtfs_captura_nova` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/1419)
+
 ## [1.3.1] - 2026-04-01
 
 ### Adicionado

--- a/pipelines/migration/br_rj_riodejaneiro_gtfs/flows.py
+++ b/pipelines/migration/br_rj_riodejaneiro_gtfs/flows.py
@@ -45,7 +45,7 @@ from pipelines.migration.tasks import (
     transform_raw_to_nested_structure_chunked,
     unpack_mapped_results_nout2,
 )
-from pipelines.schedules import every_5_minutes
+# from pipelines.schedules import every_5_minutes
 from pipelines.tasks import (
     check_fail,
     check_run_dbt_success,
@@ -306,7 +306,7 @@ gtfs_captura_nova.state_handlers = [
     handler_initialize_sentry,
     handler_skip_if_running,
 ]
-gtfs_captura_nova.schedule = every_5_minutes
+# gtfs_captura_nova.schedule = every_5_minutes
 
 
 # with Flow(

--- a/pipelines/treatment/monitoramento/CHANGELOG.md
+++ b/pipelines/treatment/monitoramento/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - monitoramento
 
+## [1.2.16] - 2026-04-29
+
+### Removido
+
+- Remove schedule dos flows `MONITORAMENTO_TEMPERATURA_MATERIALIZACAO` e `MONITORAMENTO_VEICULO_MATERIALIZACAO` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/1419)
+
 ## [1.2.15] - 2026-03-16
 
 ### Removido

--- a/pipelines/treatment/monitoramento/flows.py
+++ b/pipelines/treatment/monitoramento/flows.py
@@ -156,6 +156,7 @@ MONITORAMENTO_VEICULO_MATERIALIZACAO = create_default_materialization_flow(
     snapshot_selector=constants.SNAPSHOT_VEICULO_SELECTOR.value,
     agent_label=smtr_constants.RJ_SMTR_AGENT_LABEL.value,
     wait=[veiculo_fiscalizacao_constants.VEICULO_LACRE_SOURCE.value],
+    generate_schedule=False,
     post_tests=constants.MONITORAMENTO_VEICULO_TEST.value,
 )
 
@@ -187,6 +188,7 @@ MONITORAMENTO_TEMPERATURA_MATERIALIZACAO = create_default_materialization_flow(
     snapshot_selector=constants.SNAPSHOT_TEMPERATURA_SELECTOR.value,
     agent_label=smtr_constants.RJ_SMTR_AGENT_LABEL.value,
     wait=[constants.MONITORAMENTO_VEICULO_SELECTOR.value],
+    generate_schedule=False,
     post_tests=constants.MONITORAMENTO_TEMPERATURA_TEST.value,
 )
 


### PR DESCRIPTION
Co-authored-by: Copilot <copilot@github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Desabilitado o agendamento automático periódico para o fluxo de captura de dados de transporte. Este fluxo agora será executado apenas quando acionado manualmente.
  * Desabilitada a geração automática de agendamento para os fluxos de monitoramento de veículos e temperatura, preservando outros comportamentos existentes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->