### PR TITLE
Desativa shedule do VIAGEM_VALIDACAO_MATERIALIZACAO

### DIFF
--- a/pipelines/treatment/monitoramento/CHANGELOG.md
+++ b/pipelines/treatment/monitoramento/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - monitoramento
 
+## [1.2.17] - 2026-05-04
+
+### Removido
+
+- Remove schedule do flow `VIAGEM_VALIDACAO_MATERIALIZACAO` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/1429)
+
 ## [1.2.16] - 2026-04-29
 
 ### Removido

--- a/pipelines/treatment/monitoramento/flows.py
+++ b/pipelines/treatment/monitoramento/flows.py
@@ -58,6 +58,7 @@ VIAGEM_VALIDACAO_MATERIALIZACAO = create_default_materialization_flow(
         constants.GPS_CITTATI_SELECTOR.value,
         constants.GPS_ZIRIX_SELECTOR.value,
     ],
+    generate_schedule=False,
 )
 
 GPS_TEST_SCHEDULE_TIME = time(2, 6, 0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Desabilitada a geração automática de agendamento para o pipeline de materialização de validação de viagem, mantendo as dependências de espera funcionais.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->