### PR TITLE
Desativa generate_schedule do CAPTURA_VIAGEM_INFORMADA_BRT

### DIFF
--- a/pipelines/capture/sonda/CHANGELOG.md
+++ b/pipelines/capture/sonda/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - source_sonda
 
+## [1.0.1] - 2026-05-04
+
+### Removido
+
+- Remove schedule do flow `CAPTURA_VIAGEM_INFORMADA_BRT` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/1431)
+
 ## [1.0.0] - 2024-11-28
 
 ### Adicionado

--- a/pipelines/capture/sonda/flows.py
+++ b/pipelines/capture/sonda/flows.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Flows de captura dos dados da SONDA"""
+
 from pipelines.capture.sonda.constants import constants
 from pipelines.capture.sonda.tasks import create_viagem_informada_extractor
 from pipelines.capture.templates.flows import create_default_capture_flow
@@ -11,5 +12,6 @@ CAPTURA_VIAGEM_INFORMADA_BRT = create_default_capture_flow(
     source=constants.VIAGEM_INFORMADA_SOURCE.value,
     create_extractor_task=create_viagem_informada_extractor,
     agent_label=smtr_constants.RJ_SMTR_AGENT_LABEL.value,
+    generate_schedule=False,
 )
 set_default_parameters(CAPTURA_VIAGEM_INFORMADA_BRT, {"recapture": True})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Bug Fixes**
  * Ajustado o fluxo de captura de viagem informada para desabilitar a geração automática de agendamentos, corrigindo comportamento indesejado no processamento de dados de transporte.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->