### PR TITLE
Desativa flow de cadastro veículo

### DIFF
--- a/pipelines/treatment/cadastro/CHANGELOG.md
+++ b/pipelines/treatment/cadastro/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - cadastro
 
+## [1.1.5] - 2026-05-06
+
+### Removido
+
+- Remove schedule do flow `CADASTRO_VEICULO_MATERIALIZACAO`
+
 ## [1.1.4] - 2026-01-08
 
 ### Removido

--- a/pipelines/treatment/cadastro/CHANGELOG.md
+++ b/pipelines/treatment/cadastro/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Removido
 
-- Remove schedule do flow `CADASTRO_VEICULO_MATERIALIZACAO`
+- Remove schedule do flow `CADASTRO_VEICULO_MATERIALIZACAO` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/1439)
 
 ## [1.1.4] - 2026-01-08
 
 ### Removido
 
-- Remove schedule do flow `CADASTRO_MATERIALIZACAO`
+- Remove schedule do flow `CADASTRO_MATERIALIZACAO` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/1159)
 
 ## [1.1.3] - 2025-11-05
 

--- a/pipelines/treatment/cadastro/flows.py
+++ b/pipelines/treatment/cadastro/flows.py
@@ -40,4 +40,5 @@ CADASTRO_VEICULO_MATERIALIZACAO = create_default_materialization_flow(
     agent_label=smtr_constants.RJ_SMTR_AGENT_LABEL.value,
     wait=[monitoramento_constants.MONITORAMENTO_VEICULO_SELECTOR.value],
     post_tests=constants.CADASTRO_VEICULO_TEST.value,
+    generate_schedule=False,
 )


### PR DESCRIPTION
Co-authored-by: Copilot <copilot@github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Desativado o agendamento do fluxo de materialização de cadastro de veículos, evitando execuções programadas automáticas.
* **Documentation**
  * Adicionada entrada de changelog (v1.1.5) registrando a remoção do agendamento desse fluxo e a data da alteração.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->