### PR TITLE
Desativa flows subsidio recursos, viagem zirix e veiculo_dia

### DIFF
--- a/pipelines/migration/br_rj_riodejaneiro_recursos/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_recursos/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - br_rj_riodejaneiro_recursos
+
+## [1.0.1] - 2026-05-25
+
+### Alterado
+
+- Desativa o schedule do flow `SMTR: Subsídio Recursos - Captura/Tratamento` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/1468)

--- a/pipelines/migration/br_rj_riodejaneiro_recursos/flows.py
+++ b/pipelines/migration/br_rj_riodejaneiro_recursos/flows.py
@@ -28,7 +28,8 @@ from pipelines.migration.tasks import (
     rename_current_flow_run_now_time,
 )
 from pipelines.migration.utils import set_default_parameters
-from pipelines.schedules import every_day
+
+# from pipelines.schedules import every_day
 
 # EMD Imports #
 
@@ -207,4 +208,4 @@ subsidio_sppo_recurso.run_config = KubernetesRun(
 subsidio_sppo_recurso.state_handlers = [handler_inject_bd_credentials, handler_initialize_sentry]
 
 # Schedule
-subsidio_sppo_recurso.schedule = every_day
+# subsidio_sppo_recurso.schedule = every_day

--- a/pipelines/migration/br_rj_riodejaneiro_viagem_zirix/CHANGELOG.md
+++ b/pipelines/migration/br_rj_riodejaneiro_viagem_zirix/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - viagem_zirix
 
+## [1.1.1] - 2026-05-25
+
+### Alterado
+
+- Desativa os schedules dos flows `SMTR: Viagens Ônibus Zirix - Captura`, `SMTR: Viagens Ônibus Zirix - Recaptura` e `Viagem Zirix - Materialização` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/1468)
+
 ## [1.1.0] - 2024-06-26
 
 ### Adicionado

--- a/pipelines/migration/br_rj_riodejaneiro_viagem_zirix/flows.py
+++ b/pipelines/migration/br_rj_riodejaneiro_viagem_zirix/flows.py
@@ -17,7 +17,8 @@ from pipelines.constants import constants as smtr_constants
 from pipelines.migration.br_rj_riodejaneiro_viagem_zirix.constants import constants
 from pipelines.migration.flows import default_capture_flow, default_materialization_flow
 from pipelines.migration.utils import set_default_parameters
-from pipelines.schedules import every_10_minutes, every_hour, every_hour_minute_thirty
+
+# from pipelines.schedules import every_10_minutes, every_hour, every_hour_minute_thirty
 
 # Flows #
 
@@ -35,7 +36,7 @@ viagens_captura = set_default_parameters(
     default_parameters=constants.VIAGEM_CAPTURE_PARAMETERS.value,
 )
 
-viagens_captura.schedule = every_10_minutes
+# viagens_captura.schedule = every_10_minutes
 
 
 viagens_recaptura = deepcopy(default_capture_flow)
@@ -52,7 +53,7 @@ viagens_recaptura = set_default_parameters(
     default_parameters=constants.VIAGEM_CAPTURE_PARAMETERS.value | {"recapture": True},
 )
 
-viagens_recaptura.schedule = every_hour
+# viagens_recaptura.schedule = every_hour
 
 
 viagem_zirix_materializacao = deepcopy(default_materialization_flow)
@@ -73,4 +74,4 @@ viagem_zirix_materializacao = set_default_parameters(
     default_parameters=constants.VIAGEM_MATERIALIZACAO_PARAMS.value,
 )
 
-viagem_zirix_materializacao.schedule = every_hour_minute_thirty
+# viagem_zirix_materializacao.schedule = every_hour_minute_thirty

--- a/pipelines/migration/projeto_subsidio_sppo/flows.py
+++ b/pipelines/migration/projeto_subsidio_sppo/flows.py
@@ -48,7 +48,8 @@ from pipelines.migration.tasks import (
     split_date_range,
 )
 from pipelines.migration.veiculo.flows import sppo_veiculo_dia
-from pipelines.schedules import every_day_hour_seven_minute_five
+
+# from pipelines.schedules import every_day_hour_seven_minute_five
 from pipelines.tasks import (
     add_days_to_date,
     check_fail,
@@ -163,7 +164,8 @@ with Flow(
 
 viagens_sppo.storage = GCS(smtr_constants.GCS_FLOWS_BUCKET.value)
 viagens_sppo.run_config = KubernetesRun(
-    image=smtr_constants.DOCKER_IMAGE.value, labels=[smtr_constants.RJ_SMTR_AGENT_LABEL.value]
+    image=smtr_constants.DOCKER_IMAGE.value,
+    labels=[smtr_constants.RJ_SMTR_AGENT_LABEL.value],
 )
 viagens_sppo.state_handlers = [handler_initialize_sentry, handler_inject_bd_credentials]
 
@@ -340,12 +342,16 @@ with Flow(
         with case(skip_materialization, False):
             # 4. CALCULATE #
             date_in_range = check_date_in_range(
-                _vars["start_date"], _vars["end_date"], constants.DATA_SUBSIDIO_V9_INICIO.value
+                _vars["start_date"],
+                _vars["end_date"],
+                constants.DATA_SUBSIDIO_V9_INICIO.value,
             )
 
             with case(date_in_range, True):
                 date_intervals = split_date_range(
-                    _vars["start_date"], _vars["end_date"], constants.DATA_SUBSIDIO_V9_INICIO.value
+                    _vars["start_date"],
+                    _vars["end_date"],
+                    constants.DATA_SUBSIDIO_V9_INICIO.value,
                 )
 
                 dbt_vars_first_range = get_join_dict(
@@ -515,7 +521,8 @@ with Flow(
                         )
                     with case(date_in_range_v14, False):
                         data_maior_ou_igual_v14 = gte.run(
-                            _vars["start_date"], constants.DATA_SUBSIDIO_V14_INICIO.value
+                            _vars["start_date"],
+                            constants.DATA_SUBSIDIO_V14_INICIO.value,
                         )
 
                         with case(data_maior_ou_igual_v14, False):
@@ -628,12 +635,16 @@ with Flow(
         )
 
         date_in_range = check_date_in_range(
-            _vars["start_date"], _vars["end_date"], constants.DATA_SUBSIDIO_V9_INICIO.value
+            _vars["start_date"],
+            _vars["end_date"],
+            constants.DATA_SUBSIDIO_V9_INICIO.value,
         )
 
         with case(date_in_range, True):
             date_intervals = split_date_range(
-                _vars["start_date"], _vars["end_date"], constants.DATA_SUBSIDIO_V9_INICIO.value
+                _vars["start_date"],
+                _vars["end_date"],
+                constants.DATA_SUBSIDIO_V9_INICIO.value,
             )
 
             SUBSIDIO_SPPO_DATA_QUALITY_POS = run_dbt(
@@ -696,7 +707,9 @@ with Flow(
 
             with case(data_maior_ou_igual_v9, True):
                 date_in_range = check_date_in_range(
-                    _vars["start_date"], _vars["end_date"], constants.DATA_SUBSIDIO_V14_INICIO.value
+                    _vars["start_date"],
+                    _vars["end_date"],
+                    constants.DATA_SUBSIDIO_V14_INICIO.value,
                 )
 
                 with case(date_in_range, True):
@@ -771,7 +784,8 @@ with Flow(
                         )
 
                     SUBSIDIO_SPPO_DATA_QUALITY_POS = merge(
-                        SUBSIDIO_SPPO_DATA_QUALITY_POS_V9, SUBSIDIO_SPPO_DATA_QUALITY_POS_V14
+                        SUBSIDIO_SPPO_DATA_QUALITY_POS_V9,
+                        SUBSIDIO_SPPO_DATA_QUALITY_POS_V14,
                     )
 
                     DATA_QUALITY_POS = dbt_data_quality_checks(
@@ -782,6 +796,10 @@ with Flow(
                     )
 subsidio_sppo_apuracao.storage = GCS(smtr_constants.GCS_FLOWS_BUCKET.value)
 subsidio_sppo_apuracao.run_config = KubernetesRun(
-    image=smtr_constants.DOCKER_IMAGE.value, labels=[smtr_constants.RJ_SMTR_AGENT_LABEL.value]
+    image=smtr_constants.DOCKER_IMAGE.value,
+    labels=[smtr_constants.RJ_SMTR_AGENT_LABEL.value],
 )
-subsidio_sppo_apuracao.state_handlers = [handler_initialize_sentry, handler_inject_bd_credentials]
+subsidio_sppo_apuracao.state_handlers = [
+    handler_initialize_sentry,
+    handler_inject_bd_credentials,
+]

--- a/pipelines/treatment/monitoramento/CHANGELOG.md
+++ b/pipelines/treatment/monitoramento/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - monitoramento
 
+## [1.2.18] - 2026-05-25
+
+### Removido
+
+- Remove schedule do flow `VEICULO_DIA_MATERIALIZACAO` (https://github.com/prefeitura-rio/pipelines_rj_smtr/pull/1468)
+
 ## [1.2.17] - 2026-05-04
 
 ### Removido

--- a/pipelines/treatment/monitoramento/flows.py
+++ b/pipelines/treatment/monitoramento/flows.py
@@ -180,6 +180,7 @@ VEICULO_DIA_MATERIALIZACAO = create_default_materialization_flow(
         wait_monitoramento_veiculo,
         wait_cadastro_veiculo,
     ],
+    generate_schedule=False,
     post_tests=constants.VEICULO_DIA_TEST.value,
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Chores**
  * Desativado o agendamento automático de fluxos de sincronização de dados de subsídios do Rio de Janeiro.
  * Desativado o agendamento automático de fluxos de captura e materialização de dados de viagens.
  * Desativado o agendamento automático do fluxo de materialização de monitoramento de veículos.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prefeitura-rio/pipelines_rj_smtr/pull/1468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->